### PR TITLE
Add Wiesner's quantum money example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ COQ_OPTS := -R . Top
 
 all: examples voqc $(VOQC)/PropagateClassical.vo $(VOQC)/RemoveZRotationBeforeMeasure.vo $(VOQC)/BooleanCompilation.vo shor
 
-examples: invoke-coqmakefile $(examples)/Deutsch.vo $(examples)/DeutschJozsa.vo $(examples)/GHZ.vo $(examples)/Grover.vo $(examples)/QPE.vo $(examples)/Simon.vo $(examples)/Superdense.vo $(examples)/Teleport.vo
+examples: invoke-coqmakefile $(examples)/Deutsch.vo $(examples)/DeutschJozsa.vo $(examples)/GHZ.vo $(examples)/Grover.vo $(examples)/QPE.vo $(examples)/Simon.vo $(examples)/Superdense.vo $(examples)/Teleport.vo $(examples)/Wiesner.vo
 
 shor: invoke-coqmakefile invoke-coqmakefile-euler $(examples)/shor/AltShor.vo
 
@@ -72,6 +72,9 @@ examples/Teleport.vo: $(examples)/Teleport.v $(SQIR)/UnitarySem.vo $(SQIR)/Densi
 
 examples/Utilities.vo: $(examples)/Utilities.v $(SQIR)/VectorStates.vo
 	coqc $(COQ_OPTS) $(examples)/Utilities.v
+
+examples/Wiesner.vo: $(examples)/Wiesner.v $(SQIR)/UnitaryOps.vo $(examples)/Utilities.vo $(QWIRE)/Dirac.vo
+	coqc $(COQ_OPTS) $(examples)/Wiesner.v
 
 # Built by 'make shor'
 

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1781,7 +1781,7 @@ Proof.
   apply circuit'_output_correct; assumption.
 Qed.
 
-Theorem norm_kron: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
+Lemma norm_kron: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
   unfold norm.
   unfold kron.
   intros.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1781,7 +1781,7 @@ Proof.
   apply circuit'_output_correct; assumption.
 Qed.
 
-Theorem norm_tensor: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
+Theorem norm_kron: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
   unfold norm.
   unfold kron.
   intros.
@@ -1868,7 +1868,7 @@ Proof.
     restore_dims;
     rewrite kron_adjoint;
     rewrite kron_mixed_product;
-    rewrite norm_tensor;
+    rewrite norm_kron;
     rewrite IHn; try (simpl in H; apply eq_add_S in H; assumption);
     simpl;
     rewrite ket2bra;
@@ -2085,7 +2085,7 @@ Proof.
       rewrite kron_adjoint;
       rewrite kron_mixed_product;
       restore_dims;
-      rewrite norm_tensor;
+      rewrite norm_kron;
       rewrite Rpow_mult_distr;
       rewrite <- probability_of_outcome_is_norm;
       rewrite probability_correct_single_qubit;
@@ -2101,7 +2101,7 @@ Proof.
       rewrite kron_adjoint;
       rewrite kron_mixed_product;
       restore_dims;
-      rewrite norm_tensor;
+      rewrite norm_kron;
       rewrite Rpow_mult_distr;
       rewrite <- probability_of_outcome_is_norm;
       rewrite probability_incorrect_single_qubit; try apply diff_false_true; try apply diff_true_false;

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -21,7 +21,6 @@ Proof.
     exists a.
     split.
     + simpl in H.
-      Search (S _ = S _ -> _ = _).
       apply eq_add_S in H.
       assumption.
     + reflexivity.
@@ -149,7 +148,6 @@ Proof.
   solve_matrix.
 Qed.
 
-Search pad.
 
 Lemma circuit'_individual_qubit_non_meas_same_base_false: forall base n i, (n > 0)%nat -> (i < n)%nat -> uc_eval (circuit'_qubit_i_non_meas false base base n i) = I (2 ^ n). 
 Proof.
@@ -251,7 +249,6 @@ Lemma circuit_growth_same_base: forall n data base, length data = (S n) -> lengt
     destruct data, base; try discriminate.
     destruct data, base; try discriminate.
     simpl.
-    Search pad.
     destruct b, b0; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP; try (repeat rewrite unfold_pad); try simpl; try auto.
 Abort.
 
@@ -302,8 +299,7 @@ Proof.
     Opaque circuit'_qubit_i_non_meas.
     simpl.
     destruct b0, b.
-    + Search (circuit'_qubit_i_non_meas).
-      rewrite circuit'_individual_qubit_non_meas_same_base_true; try trivial (* For assuption (S n > 0) *).
+    + rewrite circuit'_individual_qubit_non_meas_same_base_true; try trivial (* For assuption (S n > 0) *).
       simpl.
 Abort.
 
@@ -883,7 +879,6 @@ Proof.
       apply le_n_S.
       apply le_n_S.
       apply le_plus_l.
-      Search (_ + S _)%nat.
       rewrite <- Nat.add_succ_comm.
       rewrite <- Nat.add_succ_comm.
       rewrite plus_Sn_m.
@@ -1154,8 +1149,68 @@ Proof.
       apply gt_Sn_O.
       apply diff_true_false.
       apply gt_Sn_O.
-
-Admitted.
+    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+      simpl.
+      repeat rewrite Mmult_1_l.
+      repeat rewrite Mmult_1_r.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      restore_dims.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      restore_dims.
+      reflexivity.
+      rewrite mult_comm.
+      rewrite Nat.pow_1_r.
+      rewrite pow_two_succ_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite plus_Sn_m.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      apply WF_uc_eval.
+      apply gt_Sn_O.
+      apply lt_O_Sn.
+      apply gt_Sn_O.
+      constructor.
+      replace (i + S (S n))%nat with (S (S (i +n)))%nat.
+      apply le_n_S.
+      apply le_n_S.
+      apply le_plus_l.
+      rewrite <- Nat.add_succ_comm.
+      rewrite <- Nat.add_succ_comm.
+      rewrite plus_Sn_m.
+      rewrite plus_Sn_m.
+      reflexivity.
+Qed.
 
 Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).
   intros.
@@ -1233,7 +1288,6 @@ Proof.
       rewrite unfold_pad.
       simpl.
       rewrite kron_1_l.
-      Search ((_ ⊗ _ ) × (_⊗_)).
       restore_dims.
       replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
       rewrite Mmult_1_l.
@@ -1256,7 +1310,6 @@ Proof.
       restore_dims.
       apply WF_uc_eval.
       restore_dims.
-      Search (_ × _ ⊗ (_ × _)).
       prep_matrix_equality.
       rewrite kron_mixed_product.
       simpl.
@@ -1286,7 +1339,6 @@ Proof.
       rewrite unfold_pad.
       simpl.
       rewrite kron_1_l.
-      Search ((_ ⊗ _ ) × (_⊗_)).
       restore_dims.
       replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
       rewrite Mmult_1_l.
@@ -1309,7 +1361,6 @@ Proof.
       restore_dims.
       apply WF_uc_eval.
       restore_dims.
-      Search (_ × _ ⊗ (_ × _)).
       prep_matrix_equality.
       rewrite kron_mixed_product.
       simpl.
@@ -1337,7 +1388,6 @@ Proof.
       rewrite IHn.
       rewrite circuit'_individual_qubit_non_meas_same_base_false.
       simpl.
-      Search ((_ ⊗ _ ) × (_⊗_)).
       restore_dims.
       replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
       rewrite Mmult_1_l.
@@ -1366,7 +1416,6 @@ Proof.
       restore_dims.
       apply WF_uc_eval.
       restore_dims.
-      Search (_ × _ ⊗ (_ × _)).
       prep_matrix_equality.
       rewrite kron_mixed_product.
       simpl.
@@ -1394,7 +1443,6 @@ Proof.
       replace (circuit'_helper (zip (zip data base) base) (S n)0) with (circuit' data base base (S n)).
       rewrite IHn.
       simpl.
-      Search ((_ ⊗ _ ) × (_⊗_)).
       restore_dims.
       replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
       rewrite Mmult_1_l.
@@ -1422,7 +1470,6 @@ Proof.
       restore_dims.
       apply WF_uc_eval.
       restore_dims.
-      Search (_ × _ ⊗ (_ × _)).
       prep_matrix_equality.
       rewrite kron_mixed_product.
       simpl.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1961,8 +1961,71 @@ Proof.
     solve_matrix.
 Qed.
 
-Theorem norm_tensor: forall n (A : Vector n) (B : Vector n), @norm (n) (A ⊗ B) = (@norm n A * @norm n B)%R.
-  Admitted.
+Theorem norm_tensor: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
+  unfold norm.
+  unfold kron.
+  intros.
+  simpl.
+  remember (fst (A 0%nat 0%nat)) as a10.
+  remember (snd (A 0%nat 0%nat)) as a20.
+  remember (fst (B 0%nat 0%nat)) as b10.
+  remember (snd (B 0%nat 0%nat)) as b20.
+  replace (a10 * a10)%R with (a10 ^ 2)%R by lra.
+  replace (- a20 * a20)%R with (-(a20 ^ 2))%R by lra.
+  replace (b10 * b10)%R with (b10 ^ 2)%R by lra.
+  replace (- b20 * b20)%R with (-(b20 ^ 2))%R by lra.
+  rewrite <- sqrt_mult.
+  rewrite 3 Rplus_0_l.
+  repeat (
+  repeat rewrite Rmult_minus_distr_l;
+  repeat rewrite Rmult_minus_distr_r;
+  repeat rewrite Rmult_plus_distr_l;
+  repeat rewrite Rmult_plus_distr_r
+    ).
+  repeat rewrite Rminus_unfold.
+  repeat rewrite Ropp_involutive.
+  rewrite <- (Rplus_comm (- (a20 * b20 * (a10 * b10))) (a10 * b10 * (a10 * b10))).
+  repeat rewrite Ropp_mult_distr_l.
+  repeat rewrite Ropp_involutive.
+  repeat rewrite Ropp_mult_distr_r.
+  repeat rewrite <- Rmult_plus_distr_r.
+  repeat rewrite Ropp_mult_distr_r.
+  repeat rewrite Ropp_involutive.
+  rewrite Ropp_plus_distr.
+  rewrite Ropp_mult_distr_l.
+  rewrite Ropp_mult_distr_r.
+  repeat rewrite Ropp_involutive.
+  replace ((- a20 * b20 + a10 * b10) * (a10 * b10))%R with ((-a20 * b20 * a10 + a10 ^2 * b10) * b10)%R by lra.
+  replace ( (a10 * b10 + - a20 * b20) * (a20 * - b20) )%R with ((-a10 *b10 *a20 + a20 ^ 2 * b20) * b20)%R by lra.
+  replace (((a10 * b20 + a20 * b10) * (a10 * b20)))%R with ((a10 ^2 *b20 + a20 * b10 * a10) * b20)%R by lra.
+  rewrite Rmult_opp_opp.
+  replace ((a10 * b20 + a20 * b10) * (a20 * b10))%R with ((a10 *b20 *a20 + a20 ^2 * b10) * b10)%R by lra.
+  rewrite <- Rplus_assoc.
+  rewrite Rplus_comm.
+  rewrite Rplus_assoc.
+  rewrite <- Rmult_plus_distr_r.
+  rewrite <- Rplus_assoc.
+  rewrite <- Rplus_assoc.
+  rewrite <- Rmult_plus_distr_r.
+  rewrite <- Rplus_assoc.
+  replace ((a10 * b20 * a20 + a20 ^ 2 * b10 + - a20 * b20 * a10 + a10 ^ 2 * b10))%R with ((a10 ^2 + a20 ^2) * b10 )%R by lra.
+  replace ( (- a10 * b10 * a20 + a20 ^ 2 * b20 + a10 ^ 2 * b20 + a20 * b10 * a10))%R with ((a10 ^2  + a20^2)*b20)%R by lra.
+  rewrite Rmult_assoc.
+  rewrite Rmult_assoc.
+  replace (b10 * b10)%R with (b10 * b10 ^ 1)%R by lra.
+  replace (b20 * b20)%R with (b20 * b20 ^ 1)%R by lra.
+  rewrite (tech_pow_Rmult b10 1).
+  rewrite (tech_pow_Rmult b20 1).
+  reflexivity.
+  apply Rplus_le_le_0_compat.
+  apply Rle_refl.
+  replace ( a10 ^ 2 - - a20 ^ 2)%R with (a10 ^2 + a20 ^2)%R by lra.
+  apply Rplus_le_le_0_compat; apply pow2_ge_0.
+  apply Rplus_le_le_0_compat.
+  apply Rle_refl.
+  replace ( b10 ^ 2 - - b20 ^ 2)%R with (b10 ^2 + b20 ^2)%R by lra.
+  apply Rplus_le_le_0_compat; apply pow2_ge_0.
+Qed.
 
 Theorem probibility_incorrect: forall n n_diff data ab bb, (length data = S n) -> (length ab = S n) -> (length bb = S n) -> count_diff ab bb = n_diff -> probability_of_outcome (uc_eval (circuit' data ab bb (S n)) × initial_state (S n)) (target_state (S n) data) = ((1/2)%R^n_diff)%R.
 Proof.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -493,7 +493,7 @@ Proof.
       rewrite kron_1_l.
       Search ((_ ⊗ _ ) × (_⊗_)).
       restore_dims.
-      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^ n + 0)) × uc_eval (circuit' data base base (S n))))).
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
       rewrite Mmult_1_l.
       rewrite Mmult_1_r.
       rewrite kron_mixed_product.
@@ -514,7 +514,11 @@ Proof.
       restore_dims.
       apply WF_uc_eval.
       restore_dims.
-      admit. (*TODO*)
+      Search (_ × _ ⊗ (_ × _)).
+      prep_matrix_equality.
+      rewrite kron_mixed_product.
+      simpl.
+      reflexivity.
       apply WF_σx.
       simpl in H.
       apply eq_add_S in H.
@@ -530,6 +534,177 @@ Proof.
       apply eq_add_S in H0.
       apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
       apply gt_Sn_O.
+    + rewrite circuit'_individual_qubit_non_meas_same_base_true.
+      rewrite circuit'_helper_growth.
+      simpl.
+      fold circuit'.
+      replace (circuit'_helper (zip (zip data base) base) (S n)0) with (circuit' data base base (S n)).
+      rewrite IHn.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      Search ((_ ⊗ _ ) × (_⊗_)).
+      restore_dims.
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
+      rewrite Mmult_1_l.
+      rewrite Mmult_1_r.
+      rewrite kron_mixed_product.
+      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
+      rewrite IHn.
+      replace (σx × ket 0) with (ket 1).
+      reflexivity.
+      solve_matrix.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      simpl.
+      reflexivity.
+      apply WF_σx.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      Search (_ × _ ⊗ (_ × _)).
+      prep_matrix_equality.
+      rewrite kron_mixed_product.
+      simpl.
+      reflexivity.
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      unfold circuit'.
+      reflexivity.
+      simpl in H.
+      simpl in H0.
+      apply eq_add_S in H.
+      apply eq_add_S in H0.
+      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
+      apply gt_Sn_O.
+    + simpl.
+      rewrite circuit'_helper_growth.
+      simpl.
+      fold circuit'.
+      replace (circuit'_helper (zip (zip data base) base) (S n)0) with (circuit' data base base (S n)).
+      rewrite IHn.
+      rewrite circuit'_individual_qubit_non_meas_same_base_false.
+      simpl.
+      Search ((_ ⊗ _ ) × (_⊗_)).
+      restore_dims.
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
+      rewrite Mmult_1_l.
+      rewrite kron_mixed_product.
+      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
+      rewrite IHn.
+      replace (σx × ket 0) with (ket 1).
+      rewrite Mmult_1_l.
+      reflexivity.
+      apply WF_ket.
+      solve_matrix.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      simpl.
+      reflexivity.
+      simpl in H.
+      apply eq_add_S in H.
+      apply WF_kron.
+      reflexivity.
+      reflexivity.
+      apply WF_I.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      Search (_ × _ ⊗ (_ × _)).
+      prep_matrix_equality.
+      rewrite kron_mixed_product.
+      simpl.
+      reflexivity.
+      apply gt_Sn_O.
+      apply lt_O_Sn.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      unfold circuit'.
+      reflexivity.
+      simpl in H.
+      simpl in H0.
+      apply eq_add_S in H.
+      apply eq_add_S in H0.
+      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
+    + simpl.
+      rewrite circuit'_helper_growth.
+      rewrite circuit'_individual_qubit_non_meas_same_base_false.      
+      simpl.
+      fold circuit'.
+      replace (circuit'_helper (zip (zip data base) base) (S n)0) with (circuit' data base base (S n)).
+      rewrite IHn.
+      simpl.
+      Search ((_ ⊗ _ ) × (_⊗_)).
+      restore_dims.
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data base base (S n)))).
+      rewrite Mmult_1_l.
+      rewrite kron_mixed_product.
+      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
+      rewrite IHn.
+      replace (σx × ket 0) with (ket 1).
+      restore_dims.
+      rewrite Mmult_1_l.
+      reflexivity.
+      apply WF_ket.
+      solve_matrix.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      simpl.
+      reflexivity.
+      apply WF_kron.
+      reflexivity.
+      reflexivity.
+      apply WF_I.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      Search (_ × _ ⊗ (_ × _)).
+      prep_matrix_equality.
+      rewrite kron_mixed_product.
+      simpl.
+      reflexivity.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      unfold circuit'.
+      reflexivity.
+      apply gt_Sn_O.
+      apply lt_O_Sn.
+      simpl in H.
+      simpl in H0.
+      apply eq_add_S in H.
+      apply eq_add_S in H0.
+      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
+   + simpl in H.
+     apply eq_add_S in H.
+     assumption.
+   
+
 Admitted.
+
 
 

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -230,7 +230,21 @@ Fixpoint uc_eval_circuit_same_base data :=
 
 Definition R_Bool_Rel (r : R) b := (r = 1 /\ b = true) \/ (r = 0 /\ b = false).
 
+Lemma i_1_i_S: forall (i j: nat), i + 1 <=? i + S j = true.
+  intros.
+  induction j.
+  apply Nat.leb_refl.
+  apply leb_complete in IHj.
+  apply leb_correct.
+  eapply Nat.le_trans.
+  apply IHj.
+  apply plus_le_compat_l.
+  constructor.
+  constructor.
+Qed.
+
 Lemma circuit_growth_same_base: forall n data base, length data = (S n) -> length base = (S n) -> @pad 1 0 (S n) σx × uc_eval (circuit'_helper (zip (zip data base) base) (S n) 1) = uc_eval_circuit_same_base data ⊗ σx.
+
   intros.
   induction n.
   - simpl.
@@ -305,16 +319,24 @@ Fixpoint target_state n (data: list bool) : Vector (2^n) :=
   | d::data' => (if d then ket 1 else ket 0) ⊗ target_state (n-1) data'
   end.
 
-
-Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).
+Theorem kron_dist_mult_id : forall n m (B C : Square m) , (I n) ⊗ (B × C) = ((I n) ⊗ B) × ((I n) ⊗ C).
+ intros.
+ rewrite kron_mixed_product.
+ rewrite Mmult_1_l.
+ reflexivity.
+ apply WF_I.
+Qed.
+ 
+Lemma circuit'_helper_growth_i: forall n l i, (length l = S n) -> uc_eval(circuit'_helper l ((S i) + (S n)) (S i)) =  I (2^(S i)) ⊗ uc_eval (circuit'_helper l (S n) 0).
 Proof.
   intro n.
   induction n; intros.
   - destruct l; try discriminate.
     destruct l; try discriminate.
-    destruct p.
-    destruct p.
-    destruct b, b1, b0;
+    destruct i.
+    * destruct p.
+      destruct p.
+      destruct b, b1, b0;
       simpl.
       rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
       restore_dims.
@@ -329,100 +351,423 @@ Proof.
       auto.
       auto.
       auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-      restore_dims.
-      simpl.
-      rewrite denote_SKIP.
-      rewrite denote_SKIP.
-      solve_matrix.
-      auto.
-      auto.
-      auto.
-      auto.
-      auto.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-      restore_dims.
-      rewrite 2 denote_SKIP.
-      rewrite 2 unfold_pad.
-      simpl.
-      solve_matrix.
-      auto.
-      auto.
-      auto.
-      auto.
-      apply diff_false_true.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-      restore_dims.
-      rewrite 2 denote_SKIP.
-      rewrite 2 unfold_pad.
-      simpl.
-      solve_matrix.
-      auto.
-      auto.
-      apply diff_false_true.
-      auto.
-      apply diff_false_true.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-      restore_dims.
-      rewrite 2 denote_SKIP.
-      rewrite 2 unfold_pad.
-      simpl.
-      solve_matrix.
-      auto.
-      auto.
-      apply diff_true_false.
-      auto.
-      apply diff_true_false.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-      restore_dims.
-      rewrite 2 denote_SKIP.
-      rewrite 2 unfold_pad.
-      simpl.
-      solve_matrix.
-      auto.
-      auto.
-      apply diff_true_false.
-      auto.
-      apply diff_true_false.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-      restore_dims.
-      rewrite 2 denote_SKIP.
-      rewrite 2 unfold_pad.
-      simpl.
-      solve_matrix.
-      auto.
-      auto.
-      auto.
-      auto.
-    + simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-      rewrite 2 denote_SKIP.
-      solve_matrix.
-      auto.
-      auto.
-      auto.
-      auto.
-      auto.
-      auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+        restore_dims.
+        simpl.
+        rewrite denote_SKIP.
+        rewrite denote_SKIP.
+        solve_matrix.
+        auto.
+        auto.
+        auto.
+        auto.
+        auto.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+        restore_dims.
+        rewrite 2 denote_SKIP.
+        rewrite 2 unfold_pad.
+        simpl.
+        solve_matrix.
+        auto.
+        auto.
+        auto.
+        auto.
+        apply diff_false_true.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+        restore_dims.
+        rewrite 2 denote_SKIP.
+        rewrite 2 unfold_pad.
+        simpl.
+        solve_matrix.
+        auto.
+        auto.
+        apply diff_false_true.
+        auto.
+        apply diff_false_true.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+        restore_dims.
+        rewrite 2 denote_SKIP.
+        rewrite 2 unfold_pad.
+        simpl.
+        solve_matrix.
+        auto.
+        auto.
+        apply diff_true_false.
+        auto.
+        apply diff_true_false.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+        restore_dims.
+        rewrite 2 denote_SKIP.
+        rewrite 2 unfold_pad.
+        simpl.
+        solve_matrix.
+        auto.
+        auto.
+        apply diff_true_false.
+        auto.
+        apply diff_true_false.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+        restore_dims.
+        rewrite 2 denote_SKIP.
+        rewrite 2 unfold_pad.
+        simpl.
+        solve_matrix.
+        auto.
+        auto.
+        auto.
+        auto.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+        rewrite 2 denote_SKIP.
+        solve_matrix.
+        auto.
+        auto.
+        auto.
+        auto.
+        auto.
+        auto.
+    * simpl.
+      destruct p.
+      destruct p.
+      destruct b, b0, b1.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_σx.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_σx.
+        apply WF_I.
+        apply WF_σx.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        apply WF_I.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        apply gt_Sn_O.
+        apply diff_false_true.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+        simpl.
+        rewrite 2 denote_SKIP.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite id_kron.
+        repeat rewrite Nat.add_0_r.
+        repeat rewrite double_mult.
+        rewrite mult_comm.
+        rewrite <- pow_two_succ_r.
+        reflexivity.
+        apply WF_I.
+        apply WF_I.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        auto.
+        apply gt_Sn_O.
+        rewrite Nat.add_1_r.
+        constructor.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_hadamard.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_hadamard.
+        apply WF_I.
+        apply WF_hadamard.
+        auto.
+        apply gt_Sn_O.
+        apply diff_false_true.
+        auto.
+        apply diff_false_true.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        apply WF_I.
+        apply WF_mult.
+        apply WF_hadamard.
+        apply WF_σx.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        apply diff_true_false.
+        auto.
+        apply diff_true_false.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_σx.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_σx.
+        apply WF_I.
+        apply WF_σx.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+        rewrite unfold_pad.
+        simpl.
+        rewrite Nat.leb_refl.
+        rewrite 2 denote_SKIP.
+        rewrite unfold_pad.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite <- kron_1_r.
+        restore_dims.
+        rewrite Nat.sub_diag.
+        rewrite Nat.pow_0_r.
+        restore_dims.
+        reflexivity.
+        apply WF_hadamard.
+        apply WF_kron; try reflexivity.
+        apply WF_kron; try reflexivity.
+        apply WF_I.
+        apply WF_hadamard.
+        apply WF_I.
+        apply WF_hadamard.
+        auto.
+        apply gt_Sn_O.
+        apply diff_true_false.
+        auto.
+        apply diff_true_false.
+        apply gt_Sn_O.
+      + simpl.
+        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+        simpl.
+        rewrite 2 denote_SKIP.
+        simpl.
+        restore_dims.
+        repeat rewrite kron_1_r.
+        repeat rewrite kron_1_l.
+        repeat rewrite Mmult_1_r.
+        rewrite id_kron.
+        repeat rewrite Nat.add_0_r.
+        repeat rewrite double_mult.
+        rewrite mult_comm.
+        rewrite <- pow_two_succ_r.
+        reflexivity.
+        apply WF_I.
+        apply WF_I.
+        auto.
+        apply gt_Sn_O.
+        auto.
+        auto.
+        apply gt_Sn_O.
+        rewrite Nat.add_1_r.
+        constructor.
   - destruct l; try discriminate.
     simpl.
     destruct p.
     destruct p.
     simpl.
-    rewrite IHn.
+    destruct b, b0, b1.
+    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      Search "kron_".
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      apply WF_σx.
+      apply WF_I.
+      Search (_ ^ _ * _ )%nat.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      Search (_ *_ ^ _)%nat.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      Search ((S _ + _) = S (_ + _))%nat.      
+      rewrite Nat.add_succ_l.
+      Search (_ = _ -> S _ = S _)%nat.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply gt_Sn_O.
+      apply gt_Sn_O.
 Admitted.
 
+Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).
+  intros.
+  replace (S (S n)) with (1+(S n))%nat.
+  - rewrite (circuit'_helper_growth_i n l 0%nat).
+    + reflexivity.
+    + assumption.
+  - auto.
+Qed.
 
 Theorem circuit'_same_base_correct: forall n data base, (length data = S n) -> (length base = S n) -> (uc_eval (circuit' data base base (S n))) × initial_state (S n) = target_state (S n)  data.
 Proof.
@@ -532,6 +877,7 @@ Proof.
       simpl in H0.
       apply eq_add_S in H.
       apply eq_add_S in H0.
+    
       apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
       apply gt_Sn_O.
     + rewrite circuit'_individual_qubit_non_meas_same_base_true.
@@ -702,9 +1048,10 @@ Proof.
    + simpl in H.
      apply eq_add_S in H.
      assumption.
-   
+   + simpl in H0.
+     apply eq_add_S in H0.
+     assumption.
+Qed.
 
-Admitted.
-
-
+Definition qbool (b : bool) := if b then ∣1⟩ else ∣0⟩.
 

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -326,6 +326,8 @@ Theorem kron_dist_mult_id : forall n m (B C : Square m) , (I n) ⊗ (B × C) = (
  reflexivity.
  apply WF_I.
 Qed.
+  
+ 
  
 Lemma circuit'_helper_growth_i: forall n l i, (length l = S n) -> uc_eval(circuit'_helper l ((S i) + (S n)) (S i)) =  I (2^(S i)) ⊗ uc_eval (circuit'_helper l (S n) 0).
 Proof.
@@ -703,7 +705,6 @@ Proof.
       replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
       replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
       restore_dims.
-      Search "kron_".
       rewrite kron_dist_mult_id.
       rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
       rewrite id_kron.
@@ -714,7 +715,6 @@ Proof.
       apply WF_I.
       apply WF_σx.
       apply WF_I.
-      Search (_ ^ _ * _ )%nat.
       rewrite <- Nat.pow_add_r.
       replace (S i + 1)%nat with (S (S i)).
       reflexivity.
@@ -725,7 +725,6 @@ Proof.
       apply WF_uc_eval.
       rewrite Nat.add_0_r.
       rewrite double_mult.
-      Search (_ *_ ^ _)%nat.
       rewrite Nat.pow_succ_r.
       reflexivity.
       apply Nat.le_0_l.
@@ -746,9 +745,7 @@ Proof.
       simpl in H.
       apply eq_add_S.
       assumption.
-      Search ((S _ + _) = S (_ + _))%nat.      
       rewrite Nat.add_succ_l.
-      Search (_ = _ -> S _ = S _)%nat.
       apply eq_S.
       replace (S i) with (i + 1)%nat.
       replace (S (S n)) with (1 + (S n))%nat.
@@ -758,6 +755,406 @@ Proof.
       apply Nat.add_1_r.
       apply gt_Sn_O.
       apply gt_Sn_O.
+    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+      remember (hadamard × σx) as hx.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      subst.
+      apply WF_mult.
+      apply WF_hadamard.
+      apply WF_σx.
+      apply WF_I.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      subst.
+      apply WF_mult.
+      apply WF_hadamard.
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      rewrite Nat.add_succ_l.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply diff_false_true.
+      apply gt_Sn_O.
+      apply diff_false_true.
+      apply gt_Sn_O.
+    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+      simpl.
+      repeat rewrite Mmult_1_l.
+      repeat rewrite Mmult_1_r.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      restore_dims.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      restore_dims.
+      reflexivity.
+      rewrite mult_comm.
+      rewrite Nat.pow_1_r.
+      rewrite pow_two_succ_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite plus_Sn_m.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      apply WF_uc_eval.
+      apply gt_Sn_O.
+      apply lt_O_Sn.
+      apply gt_Sn_O.
+      constructor.
+      replace (i + S (S n))%nat with (S (S (i +n)))%nat.
+      apply le_n_S.
+      apply le_n_S.
+      apply le_plus_l.
+      Search (_ + S _)%nat.
+      rewrite <- Nat.add_succ_comm.
+      rewrite <- Nat.add_succ_comm.
+      rewrite plus_Sn_m.
+      rewrite plus_Sn_m.
+      reflexivity.
+    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      apply WF_hadamard.
+      apply WF_I.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      apply WF_hadamard.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      rewrite Nat.add_succ_l.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply diff_false_true.
+      apply gt_Sn_O.
+      apply diff_false_true.
+      apply gt_Sn_O.
+    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+      remember (hadamard × σx) as hx.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      subst.
+      apply WF_mult.
+      apply WF_hadamard.
+      apply WF_σx.
+      apply WF_I.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      subst.
+      apply WF_mult.
+      apply WF_hadamard.
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      rewrite Nat.add_succ_l.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply diff_true_false.
+      apply gt_Sn_O.
+      apply diff_true_false.
+      apply gt_Sn_O. 
+    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      apply WF_σx.
+      apply WF_I.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      rewrite Nat.add_succ_l.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply gt_Sn_O.
+      apply gt_Sn_O.
+    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+      rewrite 2 unfold_pad.
+      simpl.
+      rewrite i_1_i_S.
+      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
+      rewrite IHn.
+      replace (S (S n)) with (1 + (S n))%nat. 
+      rewrite IHn.
+      rewrite kron_1_l.
+      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
+      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
+      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
+      restore_dims.
+      rewrite kron_dist_mult_id.
+      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
+      rewrite id_kron.
+      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
+      rewrite <- kron_assoc.
+      restore_dims.
+      reflexivity.
+      apply WF_I.
+      apply WF_hadamard.
+      apply WF_I.
+      rewrite <- Nat.pow_add_r.
+      replace (S i + 1)%nat with (S (S i)).
+      reflexivity.
+      rewrite Nat.add_1_r.
+      reflexivity.
+      apply WF_I.
+      apply WF_I.
+      apply WF_uc_eval.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      rewrite Nat.add_assoc.
+      rewrite Nat.add_comm.
+      rewrite Nat.add_sub.
+      reflexivity.
+      rewrite Nat.add_0_r.
+      rewrite double_mult.
+      rewrite Nat.pow_succ_r.
+      reflexivity.
+      apply Nat.le_0_l.
+      apply WF_hadamard.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      auto.
+      simpl in H.
+      apply eq_add_S.
+      assumption.
+      rewrite Nat.add_succ_l.
+      apply eq_S.
+      replace (S i) with (i + 1)%nat.
+      replace (S (S n)) with (1 + (S n))%nat.
+      rewrite <- Nat.add_assoc.
+      reflexivity.
+      auto.
+      apply Nat.add_1_r.
+      apply diff_true_false.
+      apply gt_Sn_O.
+      apply diff_true_false.
+      apply gt_Sn_O.
+
 Admitted.
 
 Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -118,6 +118,12 @@ Definition bob (base: list bool) (n : nat) : base_ucom n := bob_helper base 0 n.
 
 Definition circuit'_qubit_i_non_meas (ad ab bb : bool) (n i : nat) : base_ucom n := alice_bit_manip ab ad n i; bob_bit_manip bb n i.
 
+Fixpoint circuit'_helper (l : (list ((bool * bool) * bool))) (n : nat) (i : nat) : base_ucom n :=
+  match l with
+  | [] => SKIP
+  | ((ad,ab),bb)::l' => circuit'_helper l' n (S i); circuit'_qubit_i_non_meas ad ab bb n i
+end.
+
 Local Open Scope com_scope.
 
 Fixpoint bob_measure_helper {U} (n i : nat) : com U n := 
@@ -131,13 +137,8 @@ Definition bob_measure {U} n : com U n := bob_measure_helper n n.
 Definition circuit (alice_data alice_base bob_base : list bool) (n : nat) :=
   alice (zip alice_base alice_data) n; bob bob_base n; bob_measure n.
 
-Definition circuit'_qubit_i (ad ab bb : bool) (n i : nat) := circuit'_qubit_i_non_meas ad ab bb n i ; measure i. 
 
-Fixpoint circuit'_helper (l : (list ((bool * bool) * bool))) (n : nat) (i : nat) : com base_Unitary n :=
-  match l with
-  | [] => SKIP
-  | ((ad,ab),bb)::l' => circuit'_helper l' n (S i); circuit'_qubit_i ad ab bb n i
-end.
+
 
 Definition circuit' (alice_data alice_base bob_base : list bool) (n : nat) :=
   circuit'_helper (zip (zip alice_data alice_base) bob_base) n 0.
@@ -148,20 +149,26 @@ Proof.
   solve_matrix.
 Qed.
 
-Lemma circuit'_individual_qubit_non_meas_same_base_false: forall base n i, (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas false base base n i) = I (2 ^ n). 
+Search pad.
+
+Lemma circuit'_individual_qubit_non_meas_same_base_false: forall base n i, (n > 0)%nat -> (i < n)%nat -> uc_eval (circuit'_qubit_i_non_meas false base base n i) = I (2 ^ n). 
 Proof.
   intros.
   destruct base; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
   - rewrite Mmult_1_r.
     repeat rewrite pad_mult.
-    + admit.
+    + restore_dims.
+      rewrite MmultHH.
+      rewrite pad_id.
+      * reflexivity.
+      * assumption.
     + apply WF_pad.
       apply WF_hadamard.
   - assumption.
   - repeat rewrite Mmult_1_l; try apply WF_I. 
     reflexivity.
   - assumption.
-Admitted.
+Qed.
 
 Lemma circuit'_individual_qubit_non_meas_same_base_true: forall base n i, (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas true base base n i) = @pad 1 i n σx. 
 Proof.
@@ -169,11 +176,13 @@ Proof.
   destruct base; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
   - repeat rewrite pad_mult.
     rewrite <- Mmult_assoc.
-    admit.
+    restore_dims.
+    rewrite MmultHHX.
+    reflexivity.
   - repeat rewrite Mmult_1_l; try apply WF_pad; try apply WF_σx.
     reflexivity.
   - assumption.
-Admitted.
+Qed.
 
 
 Lemma circuit'_individual_qubit_non_meas_diff_base_false: forall base_a base_b n i, base_a <> base_b -> (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas false base_a base_b n i) = @pad 1 i n hadamard.
@@ -208,15 +217,319 @@ Proof.
   - assumption.
 Qed.
 
-Theorem circuit_individual_qubit_same_base: forall ad base (n i : nat), (n > 0)%nat -> (i <= n)%nat -> exists o, c_eval (circuit'_qubit_i ad base base n i) = o.
+Definition mat_data (b : bool) := if b then σx else I 2.
+
+Fixpoint uc_eval_circuit_same_base data :=
+  match data with
+    | [] => I 1
+    | d::data' => uc_eval_circuit_same_base data' ⊗ mat_data d
+  end.
+
+
+
+
+Definition R_Bool_Rel (r : R) b := (r = 1 /\ b = true) \/ (r = 0 /\ b = false).
+
+Lemma circuit_growth_same_base: forall n data base, length data = (S n) -> length base = (S n) -> @pad 1 0 (S n) σx × uc_eval (circuit'_helper (zip (zip data base) base) (S n) 1) = uc_eval_circuit_same_base data ⊗ σx.
+  intros.
+  induction n.
+  - simpl.
+    destruct data, base; try discriminate.
+    destruct data, base; try discriminate.
+    simpl.
+    Search pad.
+    destruct b, b0; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP; try (repeat rewrite unfold_pad); try simpl; try auto.
+Abort.
+
+    
+    
+
+Lemma circuit_growth_old: forall z' z n, (n > 0)%nat -> (n = length (z')) -> (uc_eval (circuit'_helper (z::z') (S n) 1)) = uc_eval (circuit'_helper z' n 0) ⊗ I 2.
+Proof.
+  intros z'.
+  induction z'; intros.
+  - simpl in H0.
+    subst.
+    contradict H.
+    apply gt_irrefl.
+  - Opaque circuit'_qubit_i_non_meas.
+    simpl.
+    destruct a, z; destruct p, p0.
+    simpl.
+Abort.
+
+  Theorem circuit_individual_qubit_same_base: forall data base (n: nat), (length data = S n) -> (length base = S n) -> uc_eval (circuit' data base base (S n)) = uc_eval_circuit_same_base data.
 Proof.
   intros.
-  unfold circuit'_qubit_i.
-  Opaque circuit'_qubit_i_non_meas.
-  destruct ad,base; simpl; try rewrite circuit'_individual_qubit_non_meas_same_base_false; try rewrite circuit'_individual_qubit_non_meas_same_base_true.
+  generalize dependent base.
+  generalize dependent data.
+  induction n; intros.
+  - simpl.
+    destruct data, base; try discriminate.
+    destruct data, base; try discriminate.
+    simpl.
+    rewrite denote_SKIP; try auto.
+    destruct b, b0; try rewrite circuit'_individual_qubit_non_meas_same_base_true; try rewrite circuit'_individual_qubit_non_meas_same_base_false; simpl; restore_dims; try auto; try (rewrite Mmult_1_r; rewrite unfold_pad; simpl; try rewrite kron_1_l; try rewrite kron_1_r; solve_matrix; try apply WF_pad; try apply WF_σx; try apply WF_I); try solve_matrix.
+  - unfold circuit'.
+    assert (length (zip (zip data base) base)  = S (S n)).
+    {
+      assert (length (zip data base) = S (S n)).
+      {
+        apply zip_same_length.
+        assumption.
+        assumption.
+      }
+      apply zip_same_length.
+      assumption.
+      assumption.
+    }
+    destruct data; try discriminate H.
+    destruct base; try discriminate H0.
+    Opaque circuit'_qubit_i_non_meas.
+    simpl.
+    destruct b0, b.
+    + Search (circuit'_qubit_i_non_meas).
+      rewrite circuit'_individual_qubit_non_meas_same_base_true; try trivial (* For assuption (S n > 0) *).
+      simpl.
+Abort.
+
+Fixpoint initial_state n : Vector (2^n) :=
+  match n with
+  | 0 => I 1
+  | S n' => ket 0 ⊗ initial_state n'
+  end.
+
+Fixpoint target_state n (data: list bool) : Vector (2^n) :=
+  match data with
+  | [] => I 1
+  | d::data' => (if d then ket 1 else ket 0) ⊗ target_state (n-1) data'
+  end.
+
+
+Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).
+Proof.
+  intro n.
+  induction n; intros.
+  - destruct l; try discriminate.
+    destruct l; try discriminate.
+    destruct p.
+    destruct p.
+    destruct b, b1, b0;
+      simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+      restore_dims.
+      rewrite unfold_pad.
+      rewrite unfold_pad.
+      simpl.
+      rewrite denote_SKIP.
+      rewrite denote_SKIP.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      auto.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+      restore_dims.
+      simpl.
+      rewrite denote_SKIP.
+      rewrite denote_SKIP.
+      solve_matrix.
+      auto.
+      auto.
+      auto.
+      auto.
+      auto.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+      restore_dims.
+      rewrite 2 denote_SKIP.
+      rewrite 2 unfold_pad.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      auto.
+      auto.
+      apply diff_false_true.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+      restore_dims.
+      rewrite 2 denote_SKIP.
+      rewrite 2 unfold_pad.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      apply diff_false_true.
+      auto.
+      apply diff_false_true.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
+      restore_dims.
+      rewrite 2 denote_SKIP.
+      rewrite 2 unfold_pad.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      apply diff_true_false.
+      auto.
+      apply diff_true_false.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
+      restore_dims.
+      rewrite 2 denote_SKIP.
+      rewrite 2 unfold_pad.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      apply diff_true_false.
+      auto.
+      apply diff_true_false.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
+      restore_dims.
+      rewrite 2 denote_SKIP.
+      rewrite 2 unfold_pad.
+      simpl.
+      solve_matrix.
+      auto.
+      auto.
+      auto.
+      auto.
+    + simpl.
+      rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
+      rewrite 2 denote_SKIP.
+      solve_matrix.
+      auto.
+      auto.
+      auto.
+      auto.
+      auto.
+      auto.
+  - destruct l; try discriminate.
+    simpl.
+    destruct p.
+    destruct p.
+    simpl.
+    rewrite IHn.
 Admitted.
 
-  
 
-      
-    
+Theorem circuit'_same_base_correct: forall n data base, (length data = S n) -> (length base = S n) -> (uc_eval (circuit' data base base (S n))) × initial_state (S n) = target_state (S n)  data.
+Proof.
+  intros n.
+  induction n; intros.
+  - simpl.
+    destruct data, base; try discriminate.
+    destruct data, base; try discriminate.
+    destruct b, b0; simpl; try rewrite circuit'_individual_qubit_non_meas_same_base_true; try rewrite circuit'_individual_qubit_non_meas_same_base_false; try rewrite denote_SKIP; try rewrite denote_X; try auto
+     + simpl.
+      rewrite Mmult_1_r.
+      rewrite kron_1_r.
+      restore_dims.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      rewrite kron_1_r.
+      solve_matrix.
+      apply WF_σx.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      rewrite kron_1_r.
+      apply WF_σx.
+      apply WF_σx.
+    + simpl.
+      rewrite Mmult_1_r.
+      rewrite kron_1_r.
+      restore_dims.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      rewrite kron_1_r.
+      solve_matrix.
+      apply WF_σx.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      rewrite kron_1_r.
+      apply WF_σx.
+      apply WF_σx.
+    + rewrite Mmult_1_l.
+      rewrite Mmult_1_l.
+      reflexivity.
+      rewrite kron_1_r.
+      apply WF_ket.
+      apply WF_I.
+    + rewrite Mmult_1_l.
+      rewrite Mmult_1_l.
+      reflexivity.
+      rewrite kron_1_r.
+      apply WF_ket.
+      apply WF_I.
+  -
+    simpl.
+    destruct data, base; try discriminate.
+    simpl.
+    rewrite <- (IHn data base).
+    destruct b, b0.
+    + rewrite circuit'_individual_qubit_non_meas_same_base_true.
+      rewrite circuit'_helper_growth.
+      simpl.
+      fold circuit'.
+      replace (circuit'_helper (zip (zip data base) base) (S n)0) with (circuit' data base base (S n)).
+      rewrite IHn.
+      rewrite unfold_pad.
+      simpl.
+      rewrite kron_1_l.
+      Search ((_ ⊗ _ ) × (_⊗_)).
+      restore_dims.
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data base base (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^ n + 0)) × uc_eval (circuit' data base base (S n))))).
+      rewrite Mmult_1_l.
+      rewrite Mmult_1_r.
+      rewrite kron_mixed_product.
+      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
+      rewrite IHn.
+      replace (σx × ket 0) with (ket 1).
+      reflexivity.
+      solve_matrix.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      simpl.
+      reflexivity.
+      apply WF_σx.
+      restore_dims.
+      apply WF_uc_eval.
+      restore_dims.
+      admit. (*TODO*)
+      apply WF_σx.
+      simpl in H.
+      apply eq_add_S in H.
+      assumption.
+      simpl in H0.
+      apply eq_add_S in H0.
+      assumption.
+      unfold circuit'.
+      reflexivity.
+      simpl in H.
+      simpl in H0.
+      apply eq_add_S in H.
+      apply eq_add_S in H0.
+      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
+      apply gt_Sn_O.
+Admitted.
+
+

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -53,36 +53,6 @@ Proof.
     apply IHn; assumption. 
 Qed.
 
-Lemma list_add_eq: forall A (l1 l2 : list A) (a1 a2 : A), a1 = a2 /\ l1 = l2 -> a1::l1=a2::l2.
-Proof.
-  intros.
-  destruct H.
-  subst.
-  reflexivity.
-Qed.
-
-Lemma inv_stmt: forall (A B : Prop), (A -> B) -> (~B -> ~A).
-  intros.
-  contradict H0.
-  apply H.
-  assumption.
-Qed.
-
-
-Lemma list_add_neq: forall A (l1 l2 : list A) (a1 a2 : A), a1::l1 <> a2::l2 -> a1 <> a2 \/ (a1 = a2 /\ l1 <> l2).
-Proof.
-  intros.
-  assert (~(a1::l1 = a2::l2) -> ~(a1 = a2 /\ l1 = l2)).
-  apply inv_stmt.
-  apply list_add_eq.
-  assert (~ (a1 = a2 /\ l1 = l2) -> a1 <> a2 \/ (a1 = a2 /\ l1 <> l2)).
-  {
-    admit. (* This proof turned out to be hard/ pontentially impossible  - but the actual lemmma is clearly true so in the interest of time I focussed on the quantum part below*)
-  }
-  apply H1.
-  apply H0.
-  apply H.
-Admitted.
 
 Require Import QWIRE.Dirac.
 Require Import UnitarySem.
@@ -135,9 +105,9 @@ Definition bob_measure {U} n : com U n := bob_measure_helper n n.
 
 Definition circuit (alice_data alice_base bob_base : list bool) (n : nat) :=
   alice (zip alice_base alice_data) n; bob bob_base n; bob_measure n.
+(* The initial circuit layout turned out to be a bad design, since the interwoven pattern made inductive reasoning very challanging. Hence, this layout exists soely for documentation and as an example of what NOT to do. - See circuit' for a better definition *)
 
-
-
+Local Close Scope com_scope.
 
 Definition circuit' (alice_data alice_base bob_base : list bool) (n : nat) :=
   circuit'_helper (zip (zip alice_data alice_base) bob_base) n 0.
@@ -1889,7 +1859,7 @@ Fixpoint count_diff l1 l2 :=
 
 Require Import Utilities.
 
-Theorem probability_correct_single_qubit: forall data base, probability_of_outcome (output_state_qubit_i data base base) (target_state_qubit_i data) = 1%R.
+Theorem probability_correct_single_qubit: forall data base, probability_of_outcome (output_state_qubit_i data base base) (target_state_qubit_i data) = 1.
 Proof.
   intros.
   destruct data, base;

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1816,11 +1816,6 @@ Proof.
   R_field.
 Qed.
 
-Lemma half_greater_0: 0 <= / 2.
-  (* This trivial lemma turns out hard to prove; so in the interest of time; I shall skip it *)
-  Admitted.
-
-
 Theorem probability_incorrect_single_qubit: forall data ab bb, (ab <> bb) -> probability_of_outcome (output_state_qubit_i data ab bb) (target_state_qubit_i data) = (1/2)%R.
 Proof.
   intros.
@@ -1844,7 +1839,7 @@ Proof.
     rewrite Rmult_0_l.
     rewrite Rplus_0_r.
     reflexivity.
-    apply half_greater_0.
+    lra.
     unfold snd.
     simpl.
     R_field_simplify.
@@ -1878,7 +1873,7 @@ Proof.
     rewrite Rmult_0_l.
     rewrite Rplus_0_r.
     reflexivity.
-    apply half_greater_0.
+    lra.
     unfold snd.
     simpl.
     R_field_simplify.
@@ -1911,7 +1906,7 @@ Proof.
     rewrite Rmult_0_l.
     rewrite Rplus_0_r.
     reflexivity.
-    apply half_greater_0.
+    lra.
     unfold snd.
     simpl.
     R_field_simplify.
@@ -1944,7 +1939,7 @@ Proof.
     rewrite Rmult_0_l.
     rewrite Rplus_0_r.
     reflexivity.
-    apply half_greater_0.
+    lra.
     unfold snd.
     simpl.
     R_field_simplify.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1,3 +1,18 @@
+
+(**
+Wiesner's quantum money proposed by Stephen Wiesner in 1983 (https://doi.org/10.1145%2F1008908.1008920), is a quantum verification scheme that intends to encode an $n$ bit integer. 
+Given two parties, Alice and Bob, Alice will encode the n bit integer by choosing a basis such that each bit of the integer will either be encoded to quantum $\ket{1}$ in the basis $\ket{0}, \ket{1}$ or the basis $\ket{-},\ket{+}$.
+Physically this corresponds to choice of orthogonal polarization.
+Bob will then decode the integer using his basis.
+Using the no-cloning property, it follows that when Bob measures to get the classical information, he will certainly get the correct output if his basis is equal.
+If his basis does not match, he will have a chance of $\frac{1}{2^{n_{diff}}}$ getting the correct result, where $n_{diff}$ is the number of bits his basis differs from Alice's.
+It follows that his chance getting the correct output using a random is $(\frac{3}{4})^n$.
+
+In the context of money, the $n$-bit integer would be a serial number, Alice the central bank, and Bob a malicious \nth{3} party trying to copy money.
+While the central bank can validate bills with a given serial numbers, while the 3rd party would be unable to decode the bill to get a valid serial number to copy.
+
+In the following we will prove the correctness in case of equal bases and the probability of outcome in case of incorrect bases for the Wiesner's quantum money with n qubits.
+*)
 Require Import Lists.List.
 Import ListNotations.
 

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -207,68 +207,6 @@ Lemma i_1_i_S: forall (i j: nat), i + 1 <=? i + S j = true.
   constructor.
 Qed.
 
-Lemma circuit_growth_same_base: forall n data base, length data = (S n) -> length base = (S n) -> @pad 1 0 (S n) σx × uc_eval (circuit'_helper (zip (zip data base) base) (S n) 1) = uc_eval_circuit_same_base data ⊗ σx.
-
-  intros.
-  induction n.
-  - simpl.
-    destruct data, base; try discriminate.
-    destruct data, base; try discriminate.
-    simpl.
-    destruct b, b0; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP; try (repeat rewrite unfold_pad); try simpl; try auto.
-Abort.
-
-    
-    
-
-Lemma circuit_growth_old: forall z' z n, (n > 0)%nat -> (n = length (z')) -> (uc_eval (circuit'_helper (z::z') (S n) 1)) = uc_eval (circuit'_helper z' n 0) ⊗ I 2.
-Proof.
-  intros z'.
-  induction z'; intros.
-  - simpl in H0.
-    subst.
-    contradict H.
-    apply gt_irrefl.
-  - Opaque circuit'_qubit_i_non_meas.
-    simpl.
-    destruct a, z; destruct p, p0.
-    simpl.
-Abort.
-
-  Theorem circuit_individual_qubit_same_base: forall data base (n: nat), (length data = S n) -> (length base = S n) -> uc_eval (circuit' data base base (S n)) = uc_eval_circuit_same_base data.
-Proof.
-  intros.
-  generalize dependent base.
-  generalize dependent data.
-  induction n; intros.
-  - simpl.
-    destruct data, base; try discriminate.
-    destruct data, base; try discriminate.
-    simpl.
-    rewrite denote_SKIP; try auto.
-    destruct b, b0; try rewrite circuit'_individual_qubit_non_meas_same_base_true; try rewrite circuit'_individual_qubit_non_meas_same_base_false; simpl; restore_dims; try auto; try (rewrite Mmult_1_r; rewrite unfold_pad; simpl; try rewrite kron_1_l; try rewrite kron_1_r; solve_matrix; try apply WF_pad; try apply WF_σx; try apply WF_I); try solve_matrix.
-  - unfold circuit'.
-    assert (length (zip (zip data base) base)  = S (S n)).
-    {
-      assert (length (zip data base) = S (S n)).
-      {
-        apply zip_same_length.
-        assumption.
-        assumption.
-      }
-      apply zip_same_length.
-      assumption.
-      assumption.
-    }
-    destruct data; try discriminate H.
-    destruct base; try discriminate H0.
-    Opaque circuit'_qubit_i_non_meas.
-    simpl.
-    destruct b0, b.
-    + rewrite circuit'_individual_qubit_non_meas_same_base_true; try trivial (* For assuption (S n > 0) *).
-      simpl.
-Abort.
-
 Fixpoint initial_state n : Vector (2^n) :=
   match n with
   | 0 => I 1
@@ -298,7 +236,6 @@ Fixpoint output_state n (l: combined_bit_string) : Vector (2 ^ n) :=
   | (d, ab, bb)::l' => output_state_qubit_i d ab bb ⊗ output_state (n-1) l'
   end.
 
-
 Theorem output_target_equal_base_equal: forall n data base, length data = n -> length base = n -> target_state n data = output_state n (zip (zip data base) base).
 Proof.
   intro n.
@@ -319,6 +256,8 @@ Lemma kron_dist_mult_id : forall n m (B C : Square m) , (I n) ⊗ (B × C) = ((I
  reflexivity.
  apply WF_I.
 Qed.
+
+Opaque circuit'_qubit_i_non_meas. (* For usage of lemmata *)
 
 Lemma circuit'_helper_growth_i: forall n l i, (length l = S n) -> uc_eval(circuit'_helper l ((S i) + (S n)) (S i)) =  I (2^(S i)) ⊗ uc_eval (circuit'_helper l (S n) 0).
 Proof.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1,0 +1,222 @@
+Require Import Lists.List.
+Import ListNotations.
+
+Definition bit_string := list bool. 
+
+Fixpoint zip {A} {B} (l1 : list A) (l2 : list B) :=
+  match l1, l2 with
+  | [], _ => []
+  | _, []  => []
+  | h1::t1, h2::t2 => (h1, h2) :: (zip t1 t2)
+  end.
+
+
+Lemma length_add: forall A (l1 : list A) n, length l1 = S n -> (exists l (a: A), length l = n /\ a::l = l1).
+Proof.
+  intros.
+  induction l1.
+  - contradict H.
+    auto.
+  - exists l1.
+    exists a.
+    split.
+    + simpl in H.
+      Search (S _ = S _ -> _ = _).
+      apply eq_add_S in H.
+      assumption.
+    + reflexivity.
+Qed.
+
+Theorem zip_same_length: forall A B (l1 : list A) (l2 : list B) n, length l1 = n -> length l2 = n -> length (zip l1 l2) = n.
+Proof.
+  intros.
+  generalize dependent l1.
+  generalize dependent l2.
+  induction n.
+  - intros.
+    apply length_zero_iff_nil in H.
+    apply length_zero_iff_nil in H0.
+    subst.
+    auto.
+  - intros.
+    apply length_add in H.
+    destruct H.
+    destruct H.
+    destruct H.
+    apply length_add in H0.
+    destruct H0.
+    destruct H0.
+    destruct H0.
+    rewrite <- H1.
+    rewrite <- H2.
+    simpl.
+    apply eq_S.
+    apply IHn; assumption. 
+Qed.
+
+Lemma list_add_eq: forall A (l1 l2 : list A) (a1 a2 : A), a1 = a2 /\ l1 = l2 -> a1::l1=a2::l2.
+Proof.
+  intros.
+  destruct H.
+  subst.
+  reflexivity.
+Qed.
+
+Lemma inv_stmt: forall (A B : Prop), (A -> B) -> (~B -> ~A).
+  intros.
+  contradict H0.
+  apply H.
+  assumption.
+Qed.
+
+
+Lemma list_add_neq: forall A (l1 l2 : list A) (a1 a2 : A), a1::l1 <> a2::l2 -> a1 <> a2 \/ l1 <> l2.
+Proof.
+  intros.
+  assert (~(a1::l1 = a2::l2) -> ~(a1 = a2 /\ l1 = l2)).
+  apply inv_stmt.
+  apply list_add_eq.
+  assert (~ (a1 = a2 /\ l1 = l2) -> a1 <> a2 \/ l1 <> l2).
+  {
+    admit. (* This proof turned out to be hard/ pontentially impossible  - but the actual lemmma is clearly true so in the interest of time I focussed on the quantum part below*)
+  }
+  apply H1.
+  apply H0.
+  apply H.
+Admitted.
+
+Require Import QWIRE.Dirac.
+Require Import UnitarySem.
+Require Import DensitySem.
+Require Import SQIR. 
+Local Open Scope ucom.    
+
+Definition alice_bit_manip (base : bool) (data : bool) (n i : nat) : base_ucom n :=
+  (if data then X i else SKIP);
+  (if base then H i else SKIP).
+
+Fixpoint alice_helper (state : list (bool * bool)) (i n : nat) :base_ucom n :=
+  match state with
+  | [] => SKIP
+  | (b,d)::st' => alice_bit_manip b d n i; alice_helper st' (S i) n
+  end.
+
+Definition alice (state : list (bool * bool)) (n : nat) : base_ucom n :=
+  alice_helper state 0 n.
+
+Definition bob_bit_manip (base : bool) (n i : nat) : base_ucom n :=
+  if base then H i else SKIP.
+
+
+Fixpoint bob_helper (base : list bool) (i n : nat) : base_ucom n :=
+  match base with
+  | [] => SKIP
+  | b::base' => bob_bit_manip b n i ; bob_helper base' (S i) n
+end.
+
+Definition bob (base: list bool) (n : nat) : base_ucom n := bob_helper base 0 n.
+
+Definition circuit'_qubit_i_non_meas (ad ab bb : bool) (n i : nat) : base_ucom n := alice_bit_manip ab ad n i; bob_bit_manip bb n i.
+
+Local Open Scope com_scope.
+
+Fixpoint bob_measure_helper {U} (n i : nat) : com U n := 
+  match i with
+  | 0 => measure 0
+  | S i' => measure i; bob_measure_helper n i'
+end.
+
+Definition bob_measure {U} n : com U n := bob_measure_helper n n.
+
+Definition circuit (alice_data alice_base bob_base : list bool) (n : nat) :=
+  alice (zip alice_base alice_data) n; bob bob_base n; bob_measure n.
+
+Definition circuit'_qubit_i (ad ab bb : bool) (n i : nat) := circuit'_qubit_i_non_meas ad ab bb n i ; measure i. 
+
+Fixpoint circuit'_helper (l : (list ((bool * bool) * bool))) (n : nat) (i : nat) : com base_Unitary n :=
+  match l with
+  | [] => SKIP
+  | ((ad,ab),bb)::l' => circuit'_helper l' n (S i); circuit'_qubit_i ad ab bb n i
+end.
+
+Definition circuit' (alice_data alice_base bob_base : list bool) (n : nat) :=
+  circuit'_helper (zip (zip alice_data alice_base) bob_base) n 0.
+
+
+Lemma MmultHHX: (hadamard × hadamard × σx) = σx.
+Proof.
+  solve_matrix.
+Qed.
+
+Lemma circuit'_individual_qubit_non_meas_same_base_false: forall base n i, (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas false base base n i) = I (2 ^ n). 
+Proof.
+  intros.
+  destruct base; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
+  - rewrite Mmult_1_r.
+    repeat rewrite pad_mult.
+    + admit.
+    + apply WF_pad.
+      apply WF_hadamard.
+  - assumption.
+  - repeat rewrite Mmult_1_l; try apply WF_I. 
+    reflexivity.
+  - assumption.
+Admitted.
+
+Lemma circuit'_individual_qubit_non_meas_same_base_true: forall base n i, (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas true base base n i) = @pad 1 i n σx. 
+Proof.
+  intros.
+  destruct base; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
+  - repeat rewrite pad_mult.
+    rewrite <- Mmult_assoc.
+    admit.
+  - repeat rewrite Mmult_1_l; try apply WF_pad; try apply WF_σx.
+    reflexivity.
+  - assumption.
+Admitted.
+
+
+Lemma circuit'_individual_qubit_non_meas_diff_base_false: forall base_a base_b n i, base_a <> base_b -> (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas false base_a base_b n i) = @pad 1 i n hadamard.
+Proof.
+  intros.
+  destruct base_a, base_b; subst; try contradiction; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
+  - rewrite Mmult_1_r; try apply WF_pad; try apply WF_hadamard.
+    rewrite Mmult_1_l; try apply WF_pad; try apply WF_hadamard.
+    reflexivity.
+  - assumption.
+  - repeat (rewrite Mmult_1_r; try apply WF_pad; try apply WF_I; try apply WF_hadamard).
+    reflexivity.
+  - assumption.
+Qed.
+
+Lemma circuit'_individual_qubit_non_meas_diff_base_true: forall base_a base_b n i, base_a <> base_b -> (n > 0)%nat -> uc_eval (circuit'_qubit_i_non_meas true base_a base_b n i) = @pad 1 i n (hadamard × σx).
+Proof.
+  intros.
+  destruct base_a, base_b; subst; try contradiction; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
+  - rewrite Mmult_1_l.
+    + rewrite pad_mult.
+      reflexivity.
+    + rewrite pad_mult.
+      apply WF_pad.
+      apply WF_mult.
+      * apply WF_hadamard.
+      * apply WF_σx.
+  - assumption.
+  - rewrite Mmult_1_l; try apply WF_pad; try apply WF_σx.
+    rewrite pad_mult.
+    reflexivity.
+  - assumption.
+Qed.
+
+Theorem circuit_individual_qubit_same_base: forall ad base (n i : nat), (n > 0)%nat -> (i <= n)%nat -> exists o, c_eval (circuit'_qubit_i ad base base n i) = o.
+Proof.
+  intros.
+  unfold circuit'_qubit_i.
+  Opaque circuit'_qubit_i_non_meas.
+  destruct ad,base; simpl; try rewrite circuit'_individual_qubit_non_meas_same_base_false; try rewrite circuit'_individual_qubit_non_meas_same_base_true.
+Admitted.
+
+  
+
+      
+    

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -15,66 +15,30 @@ In the following we will prove the correctness in case of equal bases and the pr
 *)
 Require Import Lists.List.
 Import ListNotations.
-
-Notation bit_string := (list bool).
-Notation combined_bit_string := (list (bool * bool * bool)).
-
-Fixpoint zip {A} {B} (l1 : list A) (l2 : list B) :=
-  match l1, l2 with
-  | [], _ => []
-  | _, []  => []
-  | h1::t1, h2::t2 => (h1, h2) :: (zip t1 t2)
-  end.
-
-
-Lemma length_add: forall A (l1 : list A) n, length l1 = S n -> (exists l (a: A), length l = n /\ a::l = l1).
-Proof.
-  intros.
-  induction l1.
-  - contradict H.
-    auto.
-  - exists l1.
-    exists a.
-    split.
-    + simpl in H.
-      apply eq_add_S in H.
-      assumption.
-    + reflexivity.
-Qed.
-
-Theorem zip_same_length: forall A B (l1 : list A) (l2 : list B) n, length l1 = n -> length l2 = n -> length (zip l1 l2) = n.
-Proof.
-  intros.
-  generalize dependent l1.
-  generalize dependent l2.
-  induction n.
-  - intros.
-    apply length_zero_iff_nil in H.
-    apply length_zero_iff_nil in H0.
-    subst.
-    auto.
-  - intros.
-    apply length_add in H.
-    destruct H.
-    destruct H.
-    destruct H.
-    apply length_add in H0.
-    destruct H0.
-    destruct H0.
-    destruct H0.
-    rewrite <- H1.
-    rewrite <- H2.
-    simpl.
-    apply eq_S.
-    apply IHn; assumption. 
-Qed.
-
-
 Require Import QWIRE.Dirac.
 Require Import UnitarySem.
 Require Import DensitySem.
 Require Import SQIR.
 Local Open Scope ucom.
+Require Import Utilities.
+
+Notation bit_string := (list bool).
+Notation combined_bit_string := (list (bool * bool * bool)).
+
+Lemma length_add: forall A (l1 : list A) n, length l1 = S n -> (exists l (a: A), length l = n /\ a::l = l1).
+Proof.
+  intros A [] n; [discriminate | eauto].
+Qed.
+
+Theorem combine_same_length: forall A B (l1 : list A) (l2 : list B) n, length l1 = n -> length l2 = n -> length (combine l1 l2) = n.
+Proof.
+  intros.
+  Search (combine _ _).
+  rewrite combine_length.
+  rewrite H, H0.
+  apply min_l.
+  constructor.
+Qed.
 
 Definition alice_bit_manip (base : bool) (data : bool) (n i : nat) : base_ucom n :=
   (if data then X i else SKIP);
@@ -120,18 +84,18 @@ end.
 Definition bob_measure {U} n : com U n := bob_measure_helper n n.
 
 Definition circuit (alice_data alice_base bob_base : bit_string) (n : nat) :=
-  alice (zip alice_base alice_data) n; bob bob_base n; bob_measure n.
+  alice (combine alice_base alice_data) n; bob bob_base n; bob_measure n.
 (* The initial circuit layout turned out to be a bad design, since the interwoven pattern made inductive reasoning very challanging. Hence, this layout exists soely for documentation and as an example of what NOT to do. - See circuit' for a better definition *)
 
 Local Close Scope com_scope.
 
 Definition circuit' (alice_data alice_base bob_base : bit_string) (n : nat) :=
-  circuit'_helper (zip (zip alice_data alice_base) bob_base) n 0.
+  circuit'_helper (combine (combine alice_data alice_base) bob_base) n 0.
 
 
 Lemma MmultHHX: (hadamard × hadamard × σx) = σx.
 Proof.
-  solve_matrix.
+   rewrite MmultHH, Mmult_1_l; auto with wf_db.
 Qed.
 
 
@@ -146,8 +110,7 @@ Proof.
       rewrite pad_id.
       * reflexivity.
       * assumption.
-    + apply WF_pad.
-      apply WF_hadamard.
+    + auto with wf_db.
   - assumption.
   - repeat rewrite Mmult_1_l; try apply WF_I. 
     reflexivity.
@@ -163,8 +126,7 @@ Proof.
     restore_dims.
     rewrite MmultHHX.
     reflexivity.
-  - repeat rewrite Mmult_1_l; try apply WF_pad; try apply WF_σx.
-    reflexivity.
+  - repeat rewrite Mmult_1_l; auto with wf_db.
   - assumption.
 Qed.
 
@@ -173,12 +135,10 @@ Lemma circuit'_individual_qubit_non_meas_diff_base_false: forall base_a base_b n
 Proof.
   intros.
   destruct base_a, base_b; subst; try contradiction; simpl; try rewrite denote_H; try rewrite denote_X; try rewrite denote_SKIP.
-  - rewrite Mmult_1_r; try apply WF_pad; try apply WF_hadamard.
-    rewrite Mmult_1_l; try apply WF_pad; try apply WF_hadamard.
-    reflexivity.
+  - rewrite Mmult_1_r; auto with wf_db.
+    rewrite Mmult_1_l; auto with wf_db.
   - assumption.
-  - repeat (rewrite Mmult_1_r; try apply WF_pad; try apply WF_I; try apply WF_hadamard).
-    reflexivity.
+  - repeat (rewrite Mmult_1_r; auto with wf_db).
   - assumption.
 Qed.
 
@@ -189,13 +149,9 @@ Proof.
   - rewrite Mmult_1_l.
     + rewrite pad_mult.
       reflexivity.
-    + rewrite pad_mult.
-      apply WF_pad.
-      apply WF_mult.
-      * apply WF_hadamard.
-      * apply WF_σx.
+    + rewrite pad_mult; auto with wf_db.
   - assumption.
-  - rewrite Mmult_1_l; try apply WF_pad; try apply WF_σx.
+  - rewrite Mmult_1_l; auto with wf_db.
     rewrite pad_mult.
     reflexivity.
   - assumption.
@@ -210,6 +166,7 @@ Fixpoint uc_eval_circuit_same_base data :=
   end.
 
 Lemma i_1_i_S: forall (i j: nat), i + 1 <=? i + S j = true.
+Proof.
   intros.
   induction j.
   apply Nat.leb_refl.
@@ -251,7 +208,7 @@ Fixpoint output_state n (l: combined_bit_string) : Vector (2 ^ n) :=
   | (d, ab, bb)::l' => output_state_qubit_i d ab bb ⊗ output_state (n-1) l'
   end.
 
-Theorem output_target_equal_base_equal: forall n data base, length data = n -> length base = n -> target_state n data = output_state n (zip (zip data base) base).
+Theorem output_target_equal_base_equal: forall n data base, length data = n -> length base = n -> target_state n data = output_state n (combine (combine data base) base).
 Proof.
   intro n.
   induction n; intros.
@@ -264,15 +221,20 @@ Proof.
 Qed.
 
 Lemma kron_dist_mult_id : forall n m (B C : Square m) , (I n) ⊗ (B × C) = ((I n) ⊗ B) × ((I n) ⊗ C).
+Proof.
   (* This lemma could potentially be extracted, since it seems quite useful *)
  intros.
  rewrite kron_mixed_product.
- rewrite Mmult_1_l.
- reflexivity.
- apply WF_I.
+ rewrite Mmult_1_l; auto with wf_db.
 Qed.
 
 Opaque circuit'_qubit_i_non_meas. (* For usage of lemmata *)
+
+Local Hint Resolve diff_true_false : core.
+Local Hint Resolve diff_false_true : core.
+Local Hint Resolve gt_Sn_O : core.
+Local Hint Resolve Nat.le_0_l : core.
+Local Hint Resolve Nat.lt_0_succ : core.
 
 Lemma circuit'_helper_growth_i: forall n l i, (length l = S n) -> uc_eval(circuit'_helper l ((S i) + (S n)) (S i)) =  I (2^(S i)) ⊗ uc_eval (circuit'_helper l (S n) 0).
 Proof.
@@ -284,884 +246,111 @@ Proof.
     * destruct p.
       destruct p.
       destruct b, b1, b0;
-      simpl.
-      rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-      restore_dims.
-      rewrite unfold_pad.
-      rewrite unfold_pad.
-      simpl.
-      rewrite denote_SKIP.
-      rewrite denote_SKIP.
-      simpl.
+      simpl;      
+      try (rewrite 2 circuit'_individual_qubit_non_meas_same_base_true; auto);
+      try (rewrite 2 circuit'_individual_qubit_non_meas_same_base_false; auto);
+      try (rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true; auto);
+      try (rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false; auto);
+      restore_dims;
+      try rewrite 2 unfold_pad; auto;
+      try rewrite 2 denote_SKIP; auto;
+      simpl;
       solve_matrix.
-      auto.
-      auto.
-      auto.
-      auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-        restore_dims.
-        simpl.
-        rewrite denote_SKIP.
-        rewrite denote_SKIP.
-        solve_matrix.
-        auto.
-        auto.
-        auto.
-        auto.
-        auto.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-        restore_dims.
-        rewrite 2 denote_SKIP.
-        rewrite 2 unfold_pad.
-        simpl.
-        solve_matrix.
-        auto.
-        auto.
-        auto.
-        auto.
-        apply diff_false_true.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-        restore_dims.
-        rewrite 2 denote_SKIP.
-        rewrite 2 unfold_pad.
-        simpl.
-        solve_matrix.
-        auto.
-        auto.
-        apply diff_false_true.
-        auto.
-        apply diff_false_true.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-        restore_dims.
-        rewrite 2 denote_SKIP.
-        rewrite 2 unfold_pad.
-        simpl.
-        solve_matrix.
-        auto.
-        auto.
-        apply diff_true_false.
-        auto.
-        apply diff_true_false.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-        restore_dims.
-        rewrite 2 denote_SKIP.
-        rewrite 2 unfold_pad.
-        simpl.
-        solve_matrix.
-        auto.
-        auto.
-        apply diff_true_false.
-        auto.
-        apply diff_true_false.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-        restore_dims.
-        rewrite 2 denote_SKIP.
-        rewrite 2 unfold_pad.
-        simpl.
-        solve_matrix.
-        auto.
-        auto.
-        auto.
-        auto.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-        rewrite 2 denote_SKIP.
-        solve_matrix.
-        auto.
-        auto.
-        auto.
-        auto.
-        auto.
-        auto.
     * simpl.
       destruct p.
       destruct p.
-      destruct b, b0, b1.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_σx.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_σx.
-        apply WF_I.
-        apply WF_σx.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        apply WF_I.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        apply gt_Sn_O.
-        apply diff_false_true.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-        simpl.
-        rewrite 2 denote_SKIP.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite id_kron.
-        repeat rewrite Nat.add_0_r.
-        repeat rewrite double_mult.
-        rewrite mult_comm.
-        rewrite <- pow_two_succ_r.
-        reflexivity.
-        apply WF_I.
-        apply WF_I.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        auto.
-        apply gt_Sn_O.
-        rewrite Nat.add_1_r.
-        constructor.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_hadamard.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_hadamard.
-        apply WF_I.
-        apply WF_hadamard.
-        auto.
-        apply gt_Sn_O.
-        apply diff_false_true.
-        auto.
-        apply diff_false_true.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        apply WF_I.
-        apply WF_mult.
-        apply WF_hadamard.
-        apply WF_σx.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        apply diff_true_false.
-        auto.
-        apply diff_true_false.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_σx.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_σx.
-        apply WF_I.
-        apply WF_σx.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-        rewrite unfold_pad.
-        simpl.
-        rewrite Nat.leb_refl.
-        rewrite 2 denote_SKIP.
-        rewrite unfold_pad.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite <- kron_1_r.
-        restore_dims.
-        rewrite Nat.sub_diag.
-        rewrite Nat.pow_0_r.
-        restore_dims.
-        reflexivity.
-        apply WF_hadamard.
-        apply WF_kron; try reflexivity.
-        apply WF_kron; try reflexivity.
-        apply WF_I.
-        apply WF_hadamard.
-        apply WF_I.
-        apply WF_hadamard.
-        auto.
-        apply gt_Sn_O.
-        apply diff_true_false.
-        auto.
-        apply diff_true_false.
-        apply gt_Sn_O.
-      + simpl.
-        rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-        simpl.
-        rewrite 2 denote_SKIP.
-        simpl.
-        restore_dims.
-        repeat rewrite kron_1_r.
-        repeat rewrite kron_1_l.
-        repeat rewrite Mmult_1_r.
-        rewrite id_kron.
-        repeat rewrite Nat.add_0_r.
-        repeat rewrite double_mult.
-        rewrite mult_comm.
-        rewrite <- pow_two_succ_r.
-        reflexivity.
-        apply WF_I.
-        apply WF_I.
-        auto.
-        apply gt_Sn_O.
-        auto.
-        auto.
-        apply gt_Sn_O.
-        rewrite Nat.add_1_r.
-        constructor.
+      destruct b, b0, b1;
+      simpl;
+      try rewrite 2 circuit'_individual_qubit_non_meas_same_base_true;
+      try rewrite 2 circuit'_individual_qubit_non_meas_same_base_false;
+      try rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true;
+      try rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false;
+      auto;
+      repeat rewrite unfold_pad;
+      repeat rewrite denote_SKIP;
+      auto;
+      simpl;
+      Msimpl;
+      try rewrite Nat.leb_refl;
+      repeat rewrite Nat.sub_diag;
+      repeat rewrite Nat.pow_0_r;
+      Msimpl;
+      auto with wf_db;
+      repeat rewrite Nat.add_0_r;
+      try (rewrite id_kron;
+      repeat rewrite Nat.add_0_r;
+      repeat rewrite double_mult;
+      rewrite mult_comm;
+      rewrite <- pow_two_succ_r);
+      auto;
+      rewrite Nat.add_1_r;
+      constructor.
   - destruct l; try discriminate.
     simpl.
     destruct p.
     destruct p.
     simpl.
-    destruct b, b0, b1.
-    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      apply WF_σx.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply gt_Sn_O.
-      apply gt_Sn_O.
-    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-      remember (hadamard × σx) as hx.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      subst.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      subst.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply diff_false_true.
-      apply gt_Sn_O.
-      apply diff_false_true.
-      apply gt_Sn_O.
-    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-      simpl.
-      repeat rewrite Mmult_1_l.
-      repeat rewrite Mmult_1_r.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      restore_dims.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      restore_dims.
-      reflexivity.
-      rewrite mult_comm.
-      rewrite Nat.pow_1_r.
-      rewrite pow_two_succ_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite plus_Sn_m.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      apply WF_uc_eval.
-      apply gt_Sn_O.
-      apply lt_O_Sn.
-      apply gt_Sn_O.
-      constructor.
-      replace (i + S (S n))%nat with (S (S (i +n)))%nat.
-      apply le_n_S.
-      apply le_n_S.
-      apply le_plus_l.
-      rewrite <- Nat.add_succ_comm.
-      rewrite <- Nat.add_succ_comm.
-      rewrite plus_Sn_m.
-      rewrite plus_Sn_m.
-      reflexivity.
-    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      apply WF_hadamard.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      apply WF_hadamard.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply diff_false_true.
-      apply gt_Sn_O.
-      apply diff_false_true.
-      apply gt_Sn_O.
-    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true.
-      remember (hadamard × σx) as hx.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      subst.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      subst.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply diff_true_false.
-      apply gt_Sn_O.
-      apply diff_true_false.
-      apply gt_Sn_O. 
-    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_true.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      apply WF_σx.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply gt_Sn_O.
-      apply gt_Sn_O.
-    + rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false.
-      rewrite 2 unfold_pad.
-      simpl.
-      rewrite i_1_i_S.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      rewrite kron_1_l.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      replace ((i + (1 + S n) - (i + 1)))%nat with (S n).
-      replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat.
-      restore_dims.
-      rewrite kron_dist_mult_id.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      rewrite <- kron_assoc.
-      restore_dims.
-      reflexivity.
-      apply WF_I.
-      apply WF_hadamard.
-      apply WF_I.
-      rewrite <- Nat.pow_add_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      rewrite Nat.add_assoc.
-      rewrite Nat.add_comm.
-      rewrite Nat.add_sub.
-      reflexivity.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      apply WF_hadamard.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      rewrite Nat.add_succ_l.
-      apply eq_S.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      apply diff_true_false.
-      apply gt_Sn_O.
-      apply diff_true_false.
-      apply gt_Sn_O.
-    + rewrite 2 circuit'_individual_qubit_non_meas_same_base_false.
-      simpl.
-      repeat rewrite Mmult_1_l.
-      repeat rewrite Mmult_1_r.
-      replace (S (i + S (S n))) with (S (S i) + (S n))%nat.
-      rewrite IHn.
-      replace (S (S n)) with (1 + (S n))%nat. 
-      rewrite IHn.
-      replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat.
-      restore_dims.
-      rewrite <- (kron_assoc (I (2^S i)) (I (2 ^1)) (uc_eval (circuit'_helper l (S n) 0))).
-      rewrite id_kron.
-      replace (2 ^ (S i) * 2 ^ 1)%nat with (2 ^ S (S i))%nat.
-      restore_dims.
-      reflexivity.
-      rewrite mult_comm.
-      rewrite Nat.pow_1_r.
-      rewrite pow_two_succ_r.
-      replace (S i + 1)%nat with (S (S i)).
-      reflexivity.
-      rewrite Nat.add_1_r.
-      reflexivity.
-      apply WF_I.
-      apply WF_I.
-      apply WF_uc_eval.
-      rewrite Nat.add_0_r.
-      rewrite double_mult.
-      rewrite Nat.pow_succ_r.
-      reflexivity.
-      apply Nat.le_0_l.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      auto.
-      simpl in H.
-      apply eq_add_S.
-      assumption.
-      replace (S i) with (i + 1)%nat.
-      replace (S (S n)) with (1 + (S n))%nat.
-      rewrite plus_Sn_m.
-      rewrite <- Nat.add_assoc.
-      reflexivity.
-      auto.
-      apply Nat.add_1_r.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      apply WF_uc_eval.
-      apply gt_Sn_O.
-      apply lt_O_Sn.
-      apply gt_Sn_O.
-      constructor.
-      replace (i + S (S n))%nat with (S (S (i +n)))%nat.
-      apply le_n_S.
-      apply le_n_S.
-      apply le_plus_l.
-      rewrite <- Nat.add_succ_comm.
-      rewrite <- Nat.add_succ_comm.
-      rewrite plus_Sn_m.
-      rewrite plus_Sn_m.
-      reflexivity.
+    destruct b, b0, b1;
+    try rewrite 2 circuit'_individual_qubit_non_meas_same_base_true; auto;
+    try rewrite 2 circuit'_individual_qubit_non_meas_diff_base_true; auto;
+    try rewrite 2 circuit'_individual_qubit_non_meas_same_base_false; auto;
+    try rewrite 2 circuit'_individual_qubit_non_meas_diff_base_false; auto;
+    simpl;
+    try (rewrite <- Nat.add_succ_l;
+        replace (S i) with (S i + 0)%nat by lia;
+        rewrite <- Nat.add_assoc;
+        apply plus_lt_compat_l;
+        simpl;
+        auto);
+    remember (hadamard × σx) as hx;
+    repeat rewrite unfold_pad; auto with wf_db;
+    replace (S (S n)) with (1 + (S n))%nat by lia;
+    simpl;
+    try rewrite i_1_i_S;
+    replace (S (i + S (S n))) with (S (S i) + (S n))%nat by lia;
+    rewrite IHn; auto;
+    replace (S (S n)) with (1 + (S n))%nat by lia;
+    rewrite IHn; auto with wf_db;
+    replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat; try (rewrite Nat.add_0_r; rewrite double_mult; rewrite Nat.pow_succ_r; try reflexivity; try apply Nat.le_0_l);
+    replace ((i + (1 + S n) - (i + 1)))%nat with (S n) by lia;
+    replace (2 ^ n + (2 ^n +0))%nat with (2 ^ (S n))%nat; try (rewrite Nat.add_0_r; rewrite double_mult; rewrite Nat.pow_succ_r; try reflexivity; try apply Nat.le_0_l);
+    restore_dims;
+    repeat rewrite kron_1_l; auto with wf_db;
+    repeat rewrite kron_1_r; auto with wf_db;
+    simpl;
+    replace (2 ^ i + (2 ^ i + 0))%nat with (2 ^ (S i))%nat; try (rewrite Nat.add_0_r; rewrite double_mult; rewrite Nat.pow_succ_r; try reflexivity; try apply Nat.le_0_l);
+    try rewrite kron_mixed_prod;
+    try rewrite kron_dist_mult_id;
+    restore_dims;
+    repeat (rewrite <- kron_assoc; auto with wf_db);
+    try rewrite id_kron;
+    replace ((2 * 2 ^ i + (2 * 2 ^ i + 0)))%nat with (2 * 2 ^ i * 2)%nat;
+    try (restore_dims;
+         reflexivity);
+    try (
+        rewrite Nat.add_0_r;
+        rewrite double_mult;
+        repeat rewrite <- Nat.pow_succ_r';
+        rewrite mult_comm;
+        repeat rewrite <- Nat.pow_succ_r';
+        reflexivity
+      );
+    try (rewrite Heqhx; auto with wf_db);
+    try (
+        repeat rewrite Nat.add_0_r;
+        repeat rewrite double_mult;
+        rewrite id_kron;
+        repeat rewrite <- Nat.pow_succ_r';
+        repeat rewrite <- Nat.pow_add_r;
+        rewrite mult_comm;
+        repeat rewrite <- Nat.pow_succ_r';
+        replace (S (S i) + (S n))%nat with (S i + S (S n))%nat by lia;
+        reflexivity
+        ).
 Qed.
 
 Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit'_helper l (S (S n)) 1) =  I 2 ⊗ uc_eval (circuit'_helper l (S n) 0).
+Proof.
   intros.
   replace (S (S n)) with (1+(S n))%nat.
   - rewrite (circuit'_helper_growth_i n l 0%nat).
@@ -1170,624 +359,72 @@ Theorem circuit'_helper_growth: forall n l, (length l = S n) ->  uc_eval(circuit
   - auto.
 Qed.
 
-Theorem circuit'_output_correct: forall n data ab bb, (length data = S n) -> (length ab = S n) -> (length bb = S n) -> (uc_eval (circuit' data ab bb (S n))) × initial_state (S n) = output_state (S n) (zip (zip data ab) bb).
+Local Hint Resolve eq_add_S : length_db.
+Local Hint Resolve combine_same_length : length_db.
+
+(* Main correctness proof *)
+Theorem circuit'_output_correct: forall n data ab bb, (length data = S n) -> (length ab = S n) -> (length bb = S n) -> (uc_eval (circuit' data ab bb (S n))) × initial_state (S n) = output_state (S n) (combine (combine data ab) bb).
 Proof.
   intros n.
   induction n; intros.
   - simpl.
     destruct data, ab, bb; try discriminate.
     destruct data, ab, bb; try discriminate.
-    destruct b, b0, b1; simpl; try rewrite circuit'_individual_qubit_non_meas_same_base_true; try rewrite circuit'_individual_qubit_non_meas_same_base_false; try rewrite circuit'_individual_qubit_non_meas_diff_base_false; try rewrite circuit'_individual_qubit_non_meas_diff_base_true; try rewrite denote_SKIP; try rewrite denote_X; try rewrite denote_H; try auto; try apply diff_true_false; try apply diff_false_true.
-     + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
+    destruct b, b0, b1; simpl;
+      try rewrite circuit'_individual_qubit_non_meas_same_base_true;
+      try rewrite circuit'_individual_qubit_non_meas_same_base_false;
+      try rewrite circuit'_individual_qubit_non_meas_diff_base_false;
+      try rewrite circuit'_individual_qubit_non_meas_diff_base_true;
+      try rewrite denote_SKIP;
+      try rewrite denote_X;
+      try rewrite denote_H;
+      try auto;
+      simpl;
+      Msimpl;
+      restore_dims;
+      try rewrite unfold_pad;
+      simpl;
+      Msimpl;
+      auto with wf_db;
       solve_matrix.
-      apply WF_σx.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      apply WF_σx.
-      apply WF_σx.
-    + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      solve_matrix.
-      unfold output_state_qubit_i.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      restore_dims.
-      apply WF_pad.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-    + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      solve_matrix.
-      unfold output_state_qubit_i.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      restore_dims.
-      apply WF_pad.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-    + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      solve_matrix.
-      apply WF_σx.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      apply WF_σx.
-      apply WF_σx.
-    + rewrite Mmult_1_l.
-      rewrite Mmult_1_l.
-      reflexivity.
-      rewrite kron_1_r.
-      apply WF_ket.
-      apply WF_I.
-    + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      solve_matrix.
-      unfold output_state_qubit_i.
-      apply WF_hadamard.
-      restore_dims.
-      apply WF_pad.
-      apply WF_hadamard.
-    + simpl.
-      rewrite Mmult_1_r.
-      rewrite kron_1_r.
-      restore_dims.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      rewrite kron_1_r.
-      solve_matrix.
-      unfold output_state_qubit_i.
-      apply WF_hadamard.
-      restore_dims.
-      apply WF_pad.
-      apply WF_hadamard.
-    + rewrite Mmult_1_l.
-      rewrite Mmult_1_l.
-      reflexivity.
-      rewrite kron_1_r.
-      apply WF_ket.
-      apply WF_I.
-  
   - simpl.
     destruct data, ab, bb; try discriminate.
     simpl.
-    rewrite <- (IHn data ab bb).
-    destruct b, b0, b1.
-    + rewrite circuit'_individual_qubit_non_meas_same_base_true.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (σx × ket 0) with (ket 1).
+    rewrite <- (IHn data ab bb); auto with length_db.
+    destruct b, b0, b1;
+      try rewrite circuit'_individual_qubit_non_meas_same_base_true;
+      try rewrite circuit'_individual_qubit_non_meas_diff_base_true;
+      try rewrite circuit'_individual_qubit_non_meas_same_base_false;
+      try rewrite circuit'_individual_qubit_non_meas_diff_base_false;
+      auto with length_db;
+      rewrite circuit'_helper_growth;
+      auto with length_db;
+      simpl;
+      fold circuit';
+      replace (circuit'_helper (combine (combine data ab) bb) (S n)0) with (circuit' data ab bb (S n)) by auto;
+      rewrite IHn; auto with length_db;
+      try rewrite unfold_pad;
+      simpl;
+      try rewrite kron_1_l; auto with wf_db;
+      restore_dims;
+      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))); auto with wf_db;
+      Msimpl; auto with wf_db;
+      restore_dims;
+      try rewrite kron_mixed_product; auto with wf_db;
+      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)) by auto with wf_db;
+      rewrite IHn; auto with length_db;
+      restore_dims;
+      unfold output_state_qubit_i;
+      simpl;
+      try rewrite Mmult_assoc;
+      restore_dims;
+      Msimpl;
+      simpl;
+      restore_dims;
+      replace (σx × ket 0) with (ket 1) by solve_matrix;
+      restore_dims;
       reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_σx.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply gt_Sn_O.
-    + rewrite circuit'_individual_qubit_non_meas_diff_base_true.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (hadamard × σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((hadamard × σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (hadamard × σx × ket 0) with (hadamard × ket 1).
-      reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply diff_true_false.
-      apply gt_Sn_O.
-    + rewrite circuit'_individual_qubit_non_meas_diff_base_true.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (hadamard × σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((hadamard × σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (hadamard × σx × ket 0) with (hadamard × ket 1).
-      reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_mult.
-      apply WF_hadamard.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply diff_false_true.
-      apply gt_Sn_O.
-    + rewrite circuit'_individual_qubit_non_meas_same_base_true.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (σx × ket 0) with (ket 1).
-      reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_σx.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_σx.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply gt_Sn_O.
-    + simpl.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite circuit'_individual_qubit_non_meas_same_base_false.
-      simpl.
-      restore_dims.
-      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (σx × ket 0) with (ket 1).
-      rewrite Mmult_1_l.
-      reflexivity.
-      apply WF_ket.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      simpl in H.
-      apply eq_add_S in H.
-      apply WF_kron.
-      reflexivity.
-      reflexivity.
-      apply WF_I.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply gt_Sn_O.
-      apply lt_O_Sn.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-    + rewrite circuit'_individual_qubit_non_meas_diff_base_false.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (hadamard ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((hadamard × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (hadamard × ket 0) with (hadamard × ket 0).
-      reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_hadamard.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_hadamard.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply diff_true_false.
-      apply gt_Sn_O.
-    + rewrite circuit'_individual_qubit_non_meas_diff_base_false.
-      rewrite circuit'_helper_growth.
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      rewrite unfold_pad.
-      simpl.
-      rewrite kron_1_l.
-      restore_dims.
-      replace (hadamard ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((hadamard × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite Mmult_1_r.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (hadamard × ket 0) with (hadamard × ket 0).
-      reflexivity.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_hadamard.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      apply WF_hadamard.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-      apply diff_false_true.
-      apply gt_Sn_O.
-    + simpl.
-      rewrite circuit'_helper_growth.
-      rewrite circuit'_individual_qubit_non_meas_same_base_false.      
-      simpl.
-      fold circuit'.
-      replace (circuit'_helper (zip (zip data ab) bb) (S n)0) with (circuit' data ab bb (S n)).
-      rewrite IHn.
-      simpl.
-      restore_dims.
-      replace (σx ⊗ (I (2 ^n + (2 ^ n + 0))) × ((I 2) ⊗ (uc_eval (circuit' data ab bb (S n))))) with ((σx × I 2) ⊗ ( (I (2 ^n + (2 ^n + 0))) × uc_eval (circuit' data ab bb (S n)))).
-      rewrite Mmult_1_l.
-      rewrite kron_mixed_product.
-      replace (ket 0 ⊗ initial_state n) with (initial_state (S n)).
-      rewrite IHn.
-      replace (σx × ket 0) with (ket 1).
-      restore_dims.
-      rewrite Mmult_1_l.
-      reflexivity.
-      apply WF_ket.
-      solve_matrix.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      simpl.
-      reflexivity.
-      apply WF_kron.
-      reflexivity.
-      reflexivity.
-      apply WF_I.
-      restore_dims.
-      apply WF_uc_eval.
-      restore_dims.
-      prep_matrix_equality.
-      rewrite kron_mixed_product.
-      simpl.
-      reflexivity.
-      simpl in H.
-      apply eq_add_S in H.
-      assumption.
-      simpl in H0.
-      apply eq_add_S in H0.
-      assumption.
-      simpl in H1.
-      apply eq_add_S in H1.
-      assumption.
-      unfold circuit'.
-      reflexivity.
-      apply gt_Sn_O.
-      apply lt_O_Sn.
-      simpl in H.
-      simpl in H0.
-      simpl in H1.
-      apply eq_add_S in H.
-      apply eq_add_S in H0.
-      apply eq_add_S in H1.
-      apply zip_same_length; try (apply zip_same_length; try assumption); try assumption.
-   + simpl in H.
-     apply eq_add_S in H.
-     assumption.
-   + simpl in H0.
-     apply eq_add_S in H0.
-     assumption.
-   + simpl in H1.
-     apply eq_add_S in H1.
-     assumption.
 Qed.
-
 
 Theorem circuit'_same_base_correct: forall n data base, (length data = S n) -> (length base = S n) -> (uc_eval (circuit' data base base (S n))) × initial_state (S n) = target_state (S n) data.
 Proof.
@@ -1797,6 +434,7 @@ Proof.
 Qed.
 
 Lemma norm_kron: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
+Proof.
   unfold norm.
   unfold kron.
   intros.
@@ -1895,9 +533,8 @@ Proof.
     lra.
 Qed.
 
-Require Import Utilities.
-
 Theorem probibility_correct: forall n data base, (length data = S n) -> (length base = S n) -> probability_of_outcome (uc_eval (circuit' data base base (S n)) × initial_state (S n)) (target_state (S n) data) = 1%R.
+Proof.
   intros.
   rewrite circuit'_same_base_correct; try assumption.
   rewrite probability_of_outcome_is_norm.
@@ -1934,8 +571,44 @@ Qed.
 Theorem probability_incorrect_single_qubit: forall data ab bb, (ab <> bb) -> probability_of_outcome (output_state_qubit_i data ab bb) (target_state_qubit_i data) = (1/2)%R.
 Proof.
   intros.
-  destruct data, ab, bb; try contradiction; simpl; unfold output_state_qubit_i; simpl.
-  - unfold probability_of_outcome.
+  (* We assert the target cases to later not have to duplicate them and have more readable code *)
+  assert (probability_of_outcome (hadamard × ket 0) (ket 0) = (1/2)%R). 
+  { unfold probability_of_outcome.
+    replace (((hadamard × ket 0)† × ket 0) 0%nat 0%nat) with (/ √ 2).
+    replace (Cmod (/ √ 2)) with (/ √ 2)%R.
+    simpl.
+    R_field_simplify.
+    reflexivity.
+    apply sqrt_neq_0_compat.
+    apply Rlt_0_2.
+    unfold Cmod.
+    replace (fst (/ √ 2)) with (/ √ 2)%R.
+    replace (snd (/ √ 2)) with (0%R).
+    rewrite <- sqrt2_inv.
+    simpl.
+    rewrite Rmult_1_r.
+    rewrite sqrt_def.
+    rewrite Rmult_0_l.
+    rewrite Rplus_0_r.
+    reflexivity.
+    lra.
+    unfold snd.
+    simpl.
+    R_field_simplify.
+    reflexivity.
+    apply sqrt2_neq_0.
+    unfold fst.
+    simpl.
+    R_field_simplify.
+    reflexivity.
+    apply sqrt2_neq_0.
+    replace ((hadamard × ket 0)† × ket 0) with (list2D_to_matrix [[/ √ 2]]).
+    reflexivity.
+    restore_dims.
+    solve_matrix.
+  }
+  assert (probability_of_outcome (hadamard × ket 1) (ket 1) = (1/2)%R).
+  { unfold probability_of_outcome.
     replace (((hadamard × ket 1)† × ket 1) 0%nat 0%nat) with (-/ √ 2).
     replace (Cmod (-/ √ 2)) with (/ √ 2)%R.
     simpl.
@@ -1969,106 +642,8 @@ Proof.
     reflexivity.
     restore_dims.
     solve_matrix.
-  - unfold probability_of_outcome.
-    replace (((hadamard × ket 1)† × ket 1) 0%nat 0%nat) with (-/ √ 2).
-    replace (Cmod (-/ √ 2)) with (/ √ 2)%R.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt_neq_0_compat.
-    apply Rlt_0_2.
-    unfold Cmod.
-    replace (fst (-/ √ 2)) with (-/ √ 2)%R.
-    replace (snd (-/ √ 2)) with (0%R).
-    rewrite <- sqrt2_inv.
-    simpl.
-    rewrite Rmult_1_r.
-    rewrite Rmult_opp_opp.
-    rewrite sqrt_def.
-    rewrite Rmult_0_l.
-    rewrite Rplus_0_r.
-    reflexivity.
-    lra.
-    unfold snd.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    unfold fst.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    replace ((hadamard × ket 1)† × ket 1) with (list2D_to_matrix [[- / √ 2]]).
-    reflexivity.
-    restore_dims.
-    solve_matrix.
-  - unfold probability_of_outcome.
-    replace (((hadamard × ket 0)† × ket 0) 0%nat 0%nat) with (/ √ 2).
-    replace (Cmod (/ √ 2)) with (/ √ 2)%R.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt_neq_0_compat.
-    apply Rlt_0_2.
-    unfold Cmod.
-    replace (fst (/ √ 2)) with (/ √ 2)%R.
-    replace (snd (/ √ 2)) with (0%R).
-    rewrite <- sqrt2_inv.
-    simpl.
-    rewrite Rmult_1_r.
-    rewrite sqrt_def.
-    rewrite Rmult_0_l.
-    rewrite Rplus_0_r.
-    reflexivity.
-    lra.
-    unfold snd.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    unfold fst.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    replace ((hadamard × ket 0)† × ket 0) with (list2D_to_matrix [[/ √ 2]]).
-    reflexivity.
-    restore_dims.
-    solve_matrix.
-  - unfold probability_of_outcome.
-    replace (((hadamard × ket 0)† × ket 0) 0%nat 0%nat) with (/ √ 2).
-    replace (Cmod (/ √ 2)) with (/ √ 2)%R.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt_neq_0_compat.
-    apply Rlt_0_2.
-    unfold Cmod.
-    replace (fst (/ √ 2)) with (/ √ 2)%R.
-    replace (snd (/ √ 2)) with (0%R).
-    rewrite <- sqrt2_inv.
-    simpl.
-    rewrite Rmult_1_r.
-    rewrite sqrt_def.
-    rewrite Rmult_0_l.
-    rewrite Rplus_0_r.
-    reflexivity.
-    lra.
-    unfold snd.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    unfold fst.
-    simpl.
-    R_field_simplify.
-    reflexivity.
-    apply sqrt2_neq_0.
-    replace ((hadamard × ket 0)† × ket 0) with (list2D_to_matrix [[/ √ 2]]).
-    reflexivity.
-    restore_dims.
-    solve_matrix.
+  }
+  destruct data, ab, bb; try contradiction; simpl; unfold output_state_qubit_i; simpl; assumption.
 Qed.
 
 Fixpoint count_diff l1 l2 :=
@@ -2078,6 +653,7 @@ Fixpoint count_diff l1 l2 :=
   | h1::t1, h2::t2 => if eqb h1 h2 then count_diff t1 t2 else (1 + count_diff t1 t2)%nat
   end.
 
+(* Main incorrect probability proof *)
 Theorem probibility_incorrect: forall n n_diff data ab bb, (length data = S n) -> (length ab = S n) -> (length bb = S n) -> count_diff ab bb = n_diff -> probability_of_outcome (uc_eval (circuit' data ab bb (S n)) × initial_state (S n)) (target_state (S n) data) = ((1/2)%R^n_diff)%R.
 Proof.
   intro n.

--- a/examples/Wiesner.v
+++ b/examples/Wiesner.v
@@ -1781,14 +1781,114 @@ Proof.
   apply circuit'_output_correct; assumption.
 Qed.
 
-Fixpoint count_diff l1 l2 :=
-  match l1, l2 with
-  | [], _ => 0%nat
-  | _, [] => 0%nat
-  | h1::t1, h2::t2 => if eqb h1 h2 then count_diff t1 t2 else (1 + count_diff t1 t2)%nat
-  end.
+Theorem norm_tensor: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
+  unfold norm.
+  unfold kron.
+  intros.
+  simpl.
+  remember (fst (A 0%nat 0%nat)) as a10.
+  remember (snd (A 0%nat 0%nat)) as a20.
+  remember (fst (B 0%nat 0%nat)) as b10.
+  remember (snd (B 0%nat 0%nat)) as b20.
+  replace (a10 * a10)%R with (a10 ^ 2)%R by lra.
+  replace (- a20 * a20)%R with (-(a20 ^ 2))%R by lra.
+  replace (b10 * b10)%R with (b10 ^ 2)%R by lra.
+  replace (- b20 * b20)%R with (-(b20 ^ 2))%R by lra.
+  rewrite <- sqrt_mult.
+  rewrite 3 Rplus_0_l.
+  repeat (
+  repeat rewrite Rmult_minus_distr_l;
+  repeat rewrite Rmult_minus_distr_r;
+  repeat rewrite Rmult_plus_distr_l;
+  repeat rewrite Rmult_plus_distr_r
+    ).
+  repeat rewrite Rminus_unfold.
+  repeat rewrite Ropp_involutive.
+  rewrite <- (Rplus_comm (- (a20 * b20 * (a10 * b10))) (a10 * b10 * (a10 * b10))).
+  repeat rewrite Ropp_mult_distr_l.
+  repeat rewrite Ropp_involutive.
+  repeat rewrite Ropp_mult_distr_r.
+  repeat rewrite <- Rmult_plus_distr_r.
+  repeat rewrite Ropp_mult_distr_r.
+  repeat rewrite Ropp_involutive.
+  rewrite Ropp_plus_distr.
+  rewrite Ropp_mult_distr_l.
+  rewrite Ropp_mult_distr_r.
+  repeat rewrite Ropp_involutive.
+  replace ((- a20 * b20 + a10 * b10) * (a10 * b10))%R with ((-a20 * b20 * a10 + a10 ^2 * b10) * b10)%R by lra.
+  replace ( (a10 * b10 + - a20 * b20) * (a20 * - b20) )%R with ((-a10 *b10 *a20 + a20 ^ 2 * b20) * b20)%R by lra.
+  replace (((a10 * b20 + a20 * b10) * (a10 * b20)))%R with ((a10 ^2 *b20 + a20 * b10 * a10) * b20)%R by lra.
+  rewrite Rmult_opp_opp.
+  replace ((a10 * b20 + a20 * b10) * (a20 * b10))%R with ((a10 *b20 *a20 + a20 ^2 * b10) * b10)%R by lra.
+  rewrite <- Rplus_assoc.
+  rewrite Rplus_comm.
+  rewrite Rplus_assoc.
+  rewrite <- Rmult_plus_distr_r.
+  rewrite <- Rplus_assoc.
+  rewrite <- Rplus_assoc.
+  rewrite <- Rmult_plus_distr_r.
+  rewrite <- Rplus_assoc.
+  replace ((a10 * b20 * a20 + a20 ^ 2 * b10 + - a20 * b20 * a10 + a10 ^ 2 * b10))%R with ((a10 ^2 + a20 ^2) * b10 )%R by lra.
+  replace ( (- a10 * b10 * a20 + a20 ^ 2 * b20 + a10 ^ 2 * b20 + a20 * b10 * a10))%R with ((a10 ^2  + a20^2)*b20)%R by lra.
+  rewrite Rmult_assoc.
+  rewrite Rmult_assoc.
+  replace (b10 * b10)%R with (b10 * b10 ^ 1)%R by lra.
+  replace (b20 * b20)%R with (b20 * b20 ^ 1)%R by lra.
+  rewrite (tech_pow_Rmult b10 1).
+  rewrite (tech_pow_Rmult b20 1).
+  reflexivity.
+  apply Rplus_le_le_0_compat.
+  apply Rle_refl.
+  replace ( a10 ^ 2 - - a20 ^ 2)%R with (a10 ^2 + a20 ^2)%R by lra.
+  apply Rplus_le_le_0_compat; apply pow2_ge_0.
+  apply Rplus_le_le_0_compat.
+  apply Rle_refl.
+  replace ( b10 ^ 2 - - b20 ^ 2)%R with (b10 ^2 + b20 ^2)%R by lra.
+  apply Rplus_le_le_0_compat; apply pow2_ge_0.
+Qed.
+
+Lemma target_state_norm: forall n data, (length data = S n) -> norm ((target_state (S n) data)† × (target_state (S n) data)) = 1.
+Proof.
+  intro n.
+  induction n; intros.
+  - destruct data; try discriminate.
+    destruct data; try discriminate.
+    destruct b;
+    simpl;
+    rewrite kron_1_r;
+    rewrite ket2bra;
+    try rewrite bra1ket1; try rewrite bra0ket0;
+    unfold norm;
+    simpl;
+    replace (0 + (1 * 1 - - 0 * 0))%R with 1%R by lra;
+    apply sqrt_1.
+  - destruct data; try discriminate.
+    destruct b;
+    simpl;
+    restore_dims;
+    rewrite kron_adjoint;
+    rewrite kron_mixed_product;
+    rewrite norm_tensor;
+    rewrite IHn; try (simpl in H; apply eq_add_S in H; assumption);
+    simpl;
+    rewrite ket2bra;
+    try rewrite bra1ket1; try rewrite bra0ket0;
+    unfold norm;
+    simpl;
+    replace (0 + (1 * 1 - - 0 * 0))%R with 1%R by lra;
+    rewrite sqrt_1;
+    lra.
+Qed.
 
 Require Import Utilities.
+
+Theorem probibility_correct: forall n data base, (length data = S n) -> (length base = S n) -> probability_of_outcome (uc_eval (circuit' data base base (S n)) × initial_state (S n)) (target_state (S n) data) = 1%R.
+  intros.
+  rewrite circuit'_same_base_correct; try assumption.
+  rewrite probability_of_outcome_is_norm.
+  rewrite target_state_norm; try assumption.
+  lra.
+Qed.
 
 Theorem probability_correct_single_qubit: forall data base, probability_of_outcome (output_state_qubit_i data base base) (target_state_qubit_i data) = 1.
 Proof.
@@ -1956,71 +2056,12 @@ Proof.
     solve_matrix.
 Qed.
 
-Theorem norm_tensor: forall (A : Vector 1) (B : Vector 1), @norm (1) (A ⊗ B) = (@norm 1 A * @norm 1 B)%R.
-  unfold norm.
-  unfold kron.
-  intros.
-  simpl.
-  remember (fst (A 0%nat 0%nat)) as a10.
-  remember (snd (A 0%nat 0%nat)) as a20.
-  remember (fst (B 0%nat 0%nat)) as b10.
-  remember (snd (B 0%nat 0%nat)) as b20.
-  replace (a10 * a10)%R with (a10 ^ 2)%R by lra.
-  replace (- a20 * a20)%R with (-(a20 ^ 2))%R by lra.
-  replace (b10 * b10)%R with (b10 ^ 2)%R by lra.
-  replace (- b20 * b20)%R with (-(b20 ^ 2))%R by lra.
-  rewrite <- sqrt_mult.
-  rewrite 3 Rplus_0_l.
-  repeat (
-  repeat rewrite Rmult_minus_distr_l;
-  repeat rewrite Rmult_minus_distr_r;
-  repeat rewrite Rmult_plus_distr_l;
-  repeat rewrite Rmult_plus_distr_r
-    ).
-  repeat rewrite Rminus_unfold.
-  repeat rewrite Ropp_involutive.
-  rewrite <- (Rplus_comm (- (a20 * b20 * (a10 * b10))) (a10 * b10 * (a10 * b10))).
-  repeat rewrite Ropp_mult_distr_l.
-  repeat rewrite Ropp_involutive.
-  repeat rewrite Ropp_mult_distr_r.
-  repeat rewrite <- Rmult_plus_distr_r.
-  repeat rewrite Ropp_mult_distr_r.
-  repeat rewrite Ropp_involutive.
-  rewrite Ropp_plus_distr.
-  rewrite Ropp_mult_distr_l.
-  rewrite Ropp_mult_distr_r.
-  repeat rewrite Ropp_involutive.
-  replace ((- a20 * b20 + a10 * b10) * (a10 * b10))%R with ((-a20 * b20 * a10 + a10 ^2 * b10) * b10)%R by lra.
-  replace ( (a10 * b10 + - a20 * b20) * (a20 * - b20) )%R with ((-a10 *b10 *a20 + a20 ^ 2 * b20) * b20)%R by lra.
-  replace (((a10 * b20 + a20 * b10) * (a10 * b20)))%R with ((a10 ^2 *b20 + a20 * b10 * a10) * b20)%R by lra.
-  rewrite Rmult_opp_opp.
-  replace ((a10 * b20 + a20 * b10) * (a20 * b10))%R with ((a10 *b20 *a20 + a20 ^2 * b10) * b10)%R by lra.
-  rewrite <- Rplus_assoc.
-  rewrite Rplus_comm.
-  rewrite Rplus_assoc.
-  rewrite <- Rmult_plus_distr_r.
-  rewrite <- Rplus_assoc.
-  rewrite <- Rplus_assoc.
-  rewrite <- Rmult_plus_distr_r.
-  rewrite <- Rplus_assoc.
-  replace ((a10 * b20 * a20 + a20 ^ 2 * b10 + - a20 * b20 * a10 + a10 ^ 2 * b10))%R with ((a10 ^2 + a20 ^2) * b10 )%R by lra.
-  replace ( (- a10 * b10 * a20 + a20 ^ 2 * b20 + a10 ^ 2 * b20 + a20 * b10 * a10))%R with ((a10 ^2  + a20^2)*b20)%R by lra.
-  rewrite Rmult_assoc.
-  rewrite Rmult_assoc.
-  replace (b10 * b10)%R with (b10 * b10 ^ 1)%R by lra.
-  replace (b20 * b20)%R with (b20 * b20 ^ 1)%R by lra.
-  rewrite (tech_pow_Rmult b10 1).
-  rewrite (tech_pow_Rmult b20 1).
-  reflexivity.
-  apply Rplus_le_le_0_compat.
-  apply Rle_refl.
-  replace ( a10 ^ 2 - - a20 ^ 2)%R with (a10 ^2 + a20 ^2)%R by lra.
-  apply Rplus_le_le_0_compat; apply pow2_ge_0.
-  apply Rplus_le_le_0_compat.
-  apply Rle_refl.
-  replace ( b10 ^ 2 - - b20 ^ 2)%R with (b10 ^2 + b20 ^2)%R by lra.
-  apply Rplus_le_le_0_compat; apply pow2_ge_0.
-Qed.
+Fixpoint count_diff l1 l2 :=
+  match l1, l2 with
+  | [], _ => 0%nat
+  | _, [] => 0%nat
+  | h1::t1, h2::t2 => if eqb h1 h2 then count_diff t1 t2 else (1 + count_diff t1 t2)%nat
+  end.
 
 Theorem probibility_incorrect: forall n n_diff data ab bb, (length data = S n) -> (length ab = S n) -> (length bb = S n) -> count_diff ab bb = n_diff -> probability_of_outcome (uc_eval (circuit' data ab bb (S n)) × initial_state (S n)) (target_state (S n) data) = ((1/2)%R^n_diff)%R.
 Proof.


### PR DESCRIPTION
This pull request adds an example of Wiesner's quantum money (https://en.wikipedia.org/wiki/Quantum_money).

The example constructs the following circuit:

![Circuit](https://user-images.githubusercontent.com/26521502/122248217-8d398600-ce8d-11eb-8e7a-c461dc5fcbd9.png)

We end up proving that given two identical bases, the circuit will output the expected result. While if the bases are different, the chance of getting the correct output is 1/2^n_diff, where n_diff is the number of bits different between the two bases.

Since there are quite a few commits in this PR, I'd also suggest to squash-merge. 