### PR TITLE
Fix parallel make, update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ all: examples voqc shor $(VOQC)/PropagateClassical.vo $(VOQC)/RemoveZRotationBef
 
 examples: invoke-coqmakefile $(examples)/Deutsch.vo $(examples)/DeutschJozsa.vo $(examples)/GHZ.vo $(examples)/Grover.vo $(examples)/QPE.vo $(examples)/Simon.vo $(examples)/Superdense.vo $(examples)/Teleport.vo $(examples)/Wiesner.vo
 
-shor: invoke-coqmakefile invoke-coqmakefile-euler $(examples)/shor/AltShor.vo
+$(examples)/shor/AltShor.vo: invoke-coqmakefile-euler
+
+shor: invoke-coqmakefile $(examples)/shor/AltShor.vo
 
 voqc: invoke-coqmakefile $(VOQC)/Main.vo
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ examples/Wiesner.vo: $(examples)/Wiesner.v $(SQIR)/UnitaryOps.vo $(examples)/Uti
 
 examples/shor/AltGateSet.vo: $(examples)/shor/AltGateSet.v $(SQIR)/UnitaryOps.vo $(SQIR)/RCIR.vo
 	coqc $(COQ_OPTS) $(examples)/shor/AltGateSet.v
-	
+
 examples/shor/AltShor.vo: $(examples)/shor/AltShor.v $(examples)/shor/AltGateSet.vo $(examples)/shor/Shor.vo
 	coqc $(COQ_OPTS) $(examples)/shor/AltShor.v
 
@@ -92,7 +92,7 @@ examples/shor/QPEGeneral.vo: $(examples)/shor/QPEGeneral.v $(examples)/QPE.vo $(
 
 examples/shor/Shor.vo: $(examples)/shor/Shor.v $(examples)/shor/QPEGeneral.vo $(examples)/shor/ModMult.vo $(examples)/shor/ShorAux.vo
 	coqc $(COQ_OPTS) $(examples)/shor/Shor.v
-	
+
 examples/shor/ShorAux.vo: $(examples)/shor/ShorAux.v $(examples)/Utilities.vo
 	coqc $(COQ_OPTS) $(examples)/shor/ShorAux.v
 
@@ -139,7 +139,7 @@ VOQC/Optimize1qGates.vo: $(VOQC)/Optimize1qGates.v $(VOQC)/IBMGateSet.vo $(VOQC)
 
 VOQC/RotationMerging.vo: $(VOQC)/RotationMerging.v $(VOQC)/RzQGateSet.vo $(SQIR)/UnitaryOps.vo $(VOQC)/MappingConstraints.vo
 	coqc $(COQ_OPTS) $(VOQC)/RotationMerging.v
-	
+
 VOQC/RzQGateSet.vo: $(VOQC)/RzQGateSet.v $(VOQC)/UnitaryListRepresentation.vo $(VOQC)/NonUnitaryListRepresentation.vo
 	coqc $(COQ_OPTS) $(VOQC)/RzQGateSet.v
 
@@ -168,5 +168,5 @@ clean:
 	rm -rf CoqMakefile CoqMakefile.conf */*/*.vo* */*/*.glob */*/*.aux */*.vo* */*.glob */*.aux .lia.cache
 
 # This should be the last rule, to handle any targets not declared above
-#%: invoke-coqmakefile
-#	@true
+%: invoke-coqmakefile
+	@true

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,6 @@ all: examples voqc shor $(VOQC)/PropagateClassical.vo $(VOQC)/RemoveZRotationBef
 
 examples: invoke-coqmakefile $(examples)/Deutsch.vo $(examples)/DeutschJozsa.vo $(examples)/GHZ.vo $(examples)/Grover.vo $(examples)/QPE.vo $(examples)/Simon.vo $(examples)/Superdense.vo $(examples)/Teleport.vo $(examples)/Wiesner.vo
 
-$(examples)/shor/AltShor.vo: invoke-coqmakefile-euler
-
 shor: invoke-coqmakefile $(examples)/shor/AltShor.vo
 
 voqc: invoke-coqmakefile $(VOQC)/Main.vo
@@ -95,7 +93,7 @@ examples/shor/QPEGeneral.vo: $(examples)/shor/QPEGeneral.v $(examples)/QPE.vo $(
 examples/shor/Shor.vo: $(examples)/shor/Shor.v $(examples)/shor/QPEGeneral.vo $(examples)/shor/ModMult.vo $(examples)/shor/ShorAux.vo
 	coqc $(COQ_OPTS) $(examples)/shor/Shor.v
 
-examples/shor/ShorAux.vo: $(examples)/shor/ShorAux.v $(examples)/Utilities.vo
+examples/shor/ShorAux.vo: invoke-coqmakefile-euler $(examples)/shor/ShorAux.v $(examples)/Utilities.vo
 	coqc $(COQ_OPTS) $(examples)/shor/ShorAux.v
 
 # Built by 'make voqc'

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ eval $(opam env)
 opam install coq
 
 # install Interval package (optional, needed to compile proofs in examples/shor)
+opam repo add coq-released https://coq.inria.fr/opam/released
 opam install coq-interval
 ```
 
 *Notes*:
-* Depending on your system, you may need to replace 4.12.0 in the instructions above with something like "ocaml-base-compiler.4.12.0". Any recent version of OCaml should be fine. 
+* Depending on your system, you may need to replace 4.12.0 in the instructions above with something like "ocaml-base-compiler.4.12.0". Any recent version of OCaml should be fine.
 * We require Coq version >= 8.12. We have tested compilation with 8.12, 8.13, and 8.14.
 * opam error messages and warnings are typically informative, so if you run into trouble then make sure you read the console output.
 
@@ -97,7 +98,7 @@ The rest of the files in the VOQC directory can be split into the following cate
 - Mapping routines
   - ConnectivityGraph.v : Utilities for describing an architecture connectivity graph. Includes graphs for linear nearest neighbor, 2D grid, and IBM Tenerife architectures.
   - Layouts.v : Utilities for describing a physical <-> logical qubit mapping.
-  - MappingConstraints.v : Utilities for describing a program that satisfies architecture constraints. 
+  - MappingConstraints.v : Utilities for describing a program that satisfies architecture constraints.
   - SimpleMapping.v: Simple mapping for an architecture described by a directed graph.
 
 - Experimental extensions

--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ opam install coq-interval
 
 ## Compilation
 
-Run `make` to compile the core files of SQIR, `make voqc` to compile proofs about VOQC, `make examples` to compile proofs of correctness for example quantum algorithms (excluding those in examples/shor), and `make shor` to compile proofs about Shor's algorithm. Use `make all` to compile everything. Our proofs are resource intensive so expect `make all` to take a little while. On a Macbook Pro running Coq version 8.14.0 and OCaml version 4.13.1 compilation takes around 30 minutes.
+Run `make` to compile the core files of SQIR, `make voqc` to compile proofs about VOQC, `make examples` to compile proofs of correctness for example quantum algorithms (excluding those in examples/shor), and `make shor` to compile proofs about Shor's algorithm. Use `make all` to compile everything. 
+
+Our proofs are resource intensive so expect `make all` to take a little while. If you have cores to spare, then you can speed things up by compiling with the `-j` flag (e.g. `make all -j8`). On a 2015 dual-core MacBook Pro running Coq version 8.14.0 compilation takes around 30 minutes.
 
 ## Directory Contents
 


### PR DESCRIPTION
Unsure why the last rule was commented out two years ago: https://github.com/inQWIRE/SQIR/commit/9e6b274d5357b849c77e85813ffa2a86b75b7318#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L122-R125

The compilation time with `make all -j16` improves to 8m 17s﻿ from ~14m with this change.
