### PR TITLE
Fix Makefile ignoring SQIR and VOQC targets on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ all:
 	git submodule update;
 	@dune build
 
-sqir:
+sqir: FORCE
 	@dune build SQIR
 
-voqc:
+voqc: FORCE
 	@dune build VOQC
 
-examples:
+examples: FORCE
 	@dune build examples
 
 shor:
@@ -35,3 +35,4 @@ doc: all
 	cd _build/default && coqdoc -g --utf8 --toc --no-lib-name -d ../../docs -R . SQIR $(FILES)
 
 .PHONY: all clean install uninstall doc
+FORCE:


### PR DESCRIPTION
Since macOS default filesystem is case-insensitive, the Makefile sees `SQIR` `VOQC` or `examples` directories and assumes no work is to be done on the `sqir` `voqc` and `examples` targets